### PR TITLE
Update site metadata

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -32,9 +32,11 @@ module.exports = Object.freeze({
     /** The name of the website. */
     title: 'Project Unicorn',
     titleShort: 'PU',
+    /** Text to be shown in the landing page heading. */
+    tag: 'Build something awesome.',
     /** The description of the website. */
     description:
-      'A virtual co-working space to learn, build, and ship meaningful software.',
+      'Project Unicorn is a virtual co-working space of software developers around the world working together to create and deploy meaningful software.',
     /** The url of the website. */
     url: 'https://projectunicorn.net',
     /** The url of the app. */

--- a/src/components/index-page/hero.tsx
+++ b/src/components/index-page/hero.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import CtaButton from './cta-button';
 import { connectedWorld } from '@images';
+import { useSiteMetadata } from '@hooks';
 import styled from '@styled-components';
 
 const Wrapper = styled.header`
@@ -61,25 +62,25 @@ const Image = styled.img.attrs({ src: connectedWorld, alt: '' })`
 `;
 
 /** Hero contains the web site's tag line and a call-to-action button. */
-const Hero: React.FC = () => (
-  <Wrapper>
-    <Text>
-      <Heading>No more to-do or weather apps.</Heading>
+const Hero: React.FC = () => {
+  const siteMetadata = useSiteMetadata();
 
-      <SubHeading>
-        Project Unicorn is an online community of software developers around the
-        world working together to create and deploy meaningful applications.
-      </SubHeading>
+  return (
+    <Wrapper>
+      <Text>
+        <Heading>{siteMetadata.tag}</Heading>
+        <SubHeading>{siteMetadata.description}</SubHeading>
 
-      <FormWrapper>
-        <CtaButton />
-      </FormWrapper>
-    </Text>
+        <FormWrapper>
+          <CtaButton />
+        </FormWrapper>
+      </Text>
 
-    <ImageWrapper>
-      <Image />
-    </ImageWrapper>
-  </Wrapper>
-);
+      <ImageWrapper>
+        <Image />
+      </ImageWrapper>
+    </Wrapper>
+  );
+};
 
 export default Hero;

--- a/src/hooks/use-site-metadata.ts
+++ b/src/hooks/use-site-metadata.ts
@@ -3,6 +3,8 @@ import { graphql, useStaticQuery } from 'gatsby';
 export interface SiteMetadata {
   /** The name of the website. */
   title: string;
+  /** Text to be shown in the landing page heading. */
+  tag: string;
   /** The description of the website. */
   description: string;
   /** The url of the website. */
@@ -39,6 +41,7 @@ const siteMetadataQuery = graphql`
     site {
       siteMetadata {
         title
+        tag
         description
         url
         appUrl


### PR DESCRIPTION
**Changes**:

- Update the web site configuration file on `<rootDir>/site.config.js`, i.e. there is now a value on `siteMetadata.tag` and the value for `siteMetadata.description` was updated
- Fix the type definitions used by the `useSiteMetadata` custom React hook.
- The index page's `<Hero />` component now uses values from the `useSiteMetadata` for the heading and sub-heading