### PR TITLE
update service resolver class to use singleton pattern for each service

### DIFF
--- a/src/api/api-service.ts
+++ b/src/api/api-service.ts
@@ -58,4 +58,9 @@ export class ApiService {
       username,
     );
   }
+
+  public updateAuthHeader(token: string) {
+    this.headers['Authorization'] = `Bearer ${token}`;
+    return;
+  }
 }

--- a/src/api/api-service.ts
+++ b/src/api/api-service.ts
@@ -61,6 +61,5 @@ export class ApiService {
 
   public updateAuthHeader(token: string) {
     this.headers['Authorization'] = `Bearer ${token}`;
-    return;
   }
 }

--- a/src/api/service-resolver.ts
+++ b/src/api/service-resolver.ts
@@ -6,21 +6,52 @@ import StackExchangeService from './stack-exchange-service';
 import MockStackExchangeService from '../mocks/mock-stack-exchange-service';
 
 export default class ServiceResolver {
-  public ApiResolver() {
-    return this.useMock() ? new MockApiService() : new ApiService();
+  private static apiServiceInstance?: MockApiService | ApiService;
+  private static authServiceInstance?: MockAuthService | AuthService;
+  private static stackExchangeServiceInstance?:
+    | MockStackExchangeService
+    | StackExchangeService;
+
+  public static apiResolver() {
+    return this.getApiServiceInstance();
   }
 
-  public AuthResolver() {
-    return this.useMock() ? new MockAuthService() : new AuthService();
+  public static authResolver() {
+    return this.getAuthServiceInstance();
   }
 
-  public StackExchangeResolver() {
-    return this.useMock()
-      ? new MockStackExchangeService()
-      : new StackExchangeService();
+  public static stackExchangeResolver() {
+    return this.getStackExchangeServiceInstance();
   }
 
-  private useMock() {
+  private static getApiServiceInstance() {
+    if (this.apiServiceInstance === undefined) {
+      this.apiServiceInstance = this.useMock()
+        ? new MockApiService()
+        : new ApiService();
+    }
+    return this.apiServiceInstance;
+  }
+
+  private static getAuthServiceInstance() {
+    if (this.authServiceInstance === undefined) {
+      this.authServiceInstance = this.useMock()
+        ? new MockAuthService()
+        : new AuthService();
+    }
+    return this.authServiceInstance;
+  }
+
+  private static getStackExchangeServiceInstance() {
+    if (this.stackExchangeServiceInstance === undefined) {
+      this.stackExchangeServiceInstance = this.useMock()
+        ? new MockStackExchangeService()
+        : new StackExchangeService();
+    }
+    return this.stackExchangeServiceInstance;
+  }
+
+  private static useMock() {
     return (
       !process.env.NODE_ENV ||
       process.env.NODE_ENV === 'development' ||

--- a/src/components/app/project-gallery/card.tsx
+++ b/src/components/app/project-gallery/card.tsx
@@ -10,13 +10,11 @@ import { ProjectUser } from '@/api/types/project-user';
 import { UserAuthHelper } from '@/helpers';
 import { ApiResponse, ErrorResponse } from '@/api/types/responses';
 import { navigate } from 'gatsby';
-import { MockApiService } from '@/mocks/mock-api-service';
-import { ApiService } from '@/api/api-service';
+import ServiceResolver from '@/api/service-resolver';
 
 interface CardProps {
   content: Project;
   setMessage: Function;
-  api: ApiService | MockApiService;
 }
 
 const Wrapper = styled.div`
@@ -65,7 +63,7 @@ const Break = styled.span`
   margin: 100px;
 `;
 
-const Card: React.FC<CardProps> = ({ content, setMessage, api }) => {
+const Card: React.FC<CardProps> = ({ content, setMessage }) => {
   const [hasMemberJoinedProject, setHasMemberJoinedProject] = React.useState(
     false,
   );
@@ -110,6 +108,7 @@ const Card: React.FC<CardProps> = ({ content, setMessage, api }) => {
   };
 
   const leaveProject = async (project: Project) => {
+    const api = ServiceResolver.apiResolver();
     setHasRequestBeenMade(true);
 
     const projectUser = project.projectUsers.find(
@@ -135,6 +134,7 @@ const Card: React.FC<CardProps> = ({ content, setMessage, api }) => {
   };
 
   const joinProject = async (project: Project) => {
+    const api = ServiceResolver.apiResolver();
     setHasRequestBeenMade(true);
     const joinProjectResponseBody: ProjectUser = {
       projectId: project.id as string,

--- a/src/components/app/project-gallery/panel.tsx
+++ b/src/components/app/project-gallery/panel.tsx
@@ -9,7 +9,6 @@ import { MockApiService } from '@/mocks/mock-api-service';
 interface PanelProps {
   content: Project[];
   setMessage: Function;
-  api: ApiService | MockApiService;
 }
 
 const Wrapper = styled.div`
@@ -18,10 +17,10 @@ const Wrapper = styled.div`
   justify-content: center;
 `;
 
-const Panel: React.FC<PanelProps> = ({ content = [], setMessage, api }) => (
+const Panel: React.FC<PanelProps> = ({ content = [], setMessage }) => (
   <Wrapper>
     {content.map((v) => (
-      <Card key={v.name} content={v} setMessage={setMessage} api={api} />
+      <Card key={v.name} content={v} setMessage={setMessage} />
     ))}
   </Wrapper>
 );

--- a/src/components/app/project-gallery/project-gallery.tsx
+++ b/src/components/app/project-gallery/project-gallery.tsx
@@ -6,8 +6,6 @@ import { Project } from '@/api/types/project';
 import { ApiResponse, ErrorResponse } from '@/api/types/responses';
 import ServiceResolver from '@/api/service-resolver';
 import { Loader } from '../shared';
-import { ApiService } from '@/api/api-service';
-import { MockApiService } from '@/mocks/mock-api-service';
 
 const Wrapper = styled.section`
   padding: ${({ theme }) => theme.boxes.padding.section.smallTop};
@@ -47,9 +45,6 @@ const ProjectGallery: React.FC = () => {
   const [isError, setIsError] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | null>('');
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
-  const [api, setApi] = React.useState<ApiService | MockApiService>(
-    new MockApiService(),
-  );
 
   const setMessage = (message: string | null) => {
     setIsError(message !== null && message !== '');
@@ -57,7 +52,7 @@ const ProjectGallery: React.FC = () => {
   };
 
   React.useEffect(() => {
-    setApi(new ServiceResolver().ApiResolver());
+    const api = ServiceResolver.apiResolver();
 
     async function fetchContent() {
       try {
@@ -94,7 +89,7 @@ const ProjectGallery: React.FC = () => {
       {isLoading ? (
         <Loader />
       ) : (
-        <Panel content={projects} setMessage={setMessage} api={api} />
+        <Panel content={projects} setMessage={setMessage} />
       )}
     </Wrapper>
   );

--- a/src/components/shared/form/create-project.tsx
+++ b/src/components/shared/form/create-project.tsx
@@ -68,7 +68,7 @@ const MessageCloseButton = styled.span`
 
 export const CreateProjectForm: React.FC = () => {
   const theme = useContext(ThemeContext);
-  const StackExchange = new ServiceResolver().StackExchangeResolver();
+  const stackExchange = ServiceResolver.stackExchangeResolver();
   const validation = new FormVal();
 
   const [formInputs, setFormInputs] = useState({
@@ -124,7 +124,7 @@ export const CreateProjectForm: React.FC = () => {
   };
 
   useEffect(() => {
-    const api = new ServiceResolver().ApiResolver();
+    const api = ServiceResolver.apiResolver();
 
     if (!UserAuthHelper.isUserAuthenticated()) {
       navigate('/signin', {
@@ -153,7 +153,7 @@ export const CreateProjectForm: React.FC = () => {
 
   const promiseOptions = async (inputValue: string) => {
     try {
-      const data = (await StackExchange.searchTags(inputValue)) as Tag;
+      const data = (await stackExchange.searchTags(inputValue)) as Tag;
       return data.items.map((item: Item) => ({
         value: item.name,
         label: item.name,
@@ -226,7 +226,7 @@ export const CreateProjectForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const api = new ServiceResolver().ApiResolver();
+    const api = ServiceResolver.apiResolver();
 
     const { pName, pDesc, pTech, pType, pRepo, pLaunch, pComm } = formInputs;
     const errors = validation.checkValidation(formInputs);

--- a/src/components/shared/form/sign-up.tsx
+++ b/src/components/shared/form/sign-up.tsx
@@ -15,10 +15,6 @@ import { UserValidation } from '@/api/types/user-validation';
 import { Button } from '@components/app/shared';
 import { JwtToken } from '@/api/types/jwt-token';
 import { SessionStorageHelper } from '@/helpers';
-import { MockApiService } from '@/mocks/mock-api-service';
-import { MockAuthService } from '@/mocks/mock-auth-service';
-import { ApiService } from '@/api/api-service';
-import { AuthService } from '@/api/auth-service';
 import { FormVal } from '@/utils/form-validation';
 import { Username } from '@/api/types/username';
 
@@ -61,17 +57,10 @@ export const SignUpForm: React.FC = () => {
 
   const [formErrors, setFormErrors] = useState<string[]>([]);
   const [message, setMessage] = useState<string | UserValidation>();
-  const [api, setApi] = useState<MockApiService | ApiService>();
-  const [auth, setAuth] = useState<MockAuthService | AuthService>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [usernameAvailablity, setUsernameAvailability] = useState<
     UserValidation
   >({ valid: false, reason: '' });
-
-  React.useEffect(() => {
-    setAuth(new ServiceResolver().AuthResolver());
-    setApi(new ServiceResolver().ApiResolver());
-  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -83,7 +72,7 @@ export const SignUpForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
+    const auth = ServiceResolver.authResolver();
     const errors = validation.userSignUp(formInputs);
 
     if (errors.length) return setFormErrors([...errors]);
@@ -93,9 +82,9 @@ export const SignUpForm: React.FC = () => {
       const locale =
         typeof window.navigator !== 'undefined'
           ? window.navigator.language
-          : 'en';
+          : 'en-US';
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      const response = (await (auth as MockAuthService | AuthService).signUp({
+      const response = (await auth.signUp({
         username: formInputs.username.val,
         email: formInputs.email.val,
         password: formInputs.password.val,
@@ -141,6 +130,7 @@ export const SignUpForm: React.FC = () => {
   };
 
   const checkUsername = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const api = ServiceResolver.apiResolver();
     const { name, value } = e.target;
     const state: any = formInputs;
     state[name].val = value;
@@ -151,9 +141,7 @@ export const SignUpForm: React.FC = () => {
         username: value,
       };
       try {
-        const response = (await (api as
-          | MockApiService
-          | ApiService).validateUsername(username)) as ApiResponse<
+        const response = (await api.validateUsername(username)) as ApiResponse<
           UserValidation | ErrorResponse
         >;
 

--- a/src/helpers/session-storage-helper.ts
+++ b/src/helpers/session-storage-helper.ts
@@ -1,9 +1,12 @@
 import { JwtToken } from '@/api/types/jwt-token';
+import ServiceResolver from '@/api/service-resolver';
+import { ApiService } from '@/api/api-service';
 
 export default class SessionStorageHelper {
   public static storeJwt(jsonWebToken: object) {
     const jwtData = this.stringifySessionData(jsonWebToken);
     localStorage.setItem('currentJwt', jwtData);
+    this.updateAuthorizationHeader(this.getJwt().token);
   }
 
   public static getJwt(): JwtToken {
@@ -35,5 +38,13 @@ export default class SessionStorageHelper {
 
   public static deleteJwt() {
     localStorage.removeItem('currentJwt');
+    this.updateAuthorizationHeader(this.getJwt().token);
+  }
+
+  public static updateAuthorizationHeader(token?: string) {
+    const api = ServiceResolver.apiResolver();
+    if (api instanceof ApiService) {
+      api.updateAuthHeader(token || '');
+    }
   }
 }

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -54,11 +54,8 @@ const SignInPage: React.FC<SignInPageProps> = ({ location }) => {
   const [password, setPassword] = useState<string>('');
   const [message, setMessage] = useState<string>('');
   const [isSigningIn, setIsSigningIn] = useState<boolean>(false);
-  const [auth, setAuth] = useState<MockAuthService | AuthService>();
 
   React.useEffect(() => {
-    setAuth(new ServiceResolver().AuthResolver());
-
     if (location.state !== null) {
       setMessage(location.state.message);
     }
@@ -66,6 +63,7 @@ const SignInPage: React.FC<SignInPageProps> = ({ location }) => {
 
   const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
+    const auth = ServiceResolver.authResolver();
 
     if (email === '' || password === '') {
       setMessage('Invalid email or password');
@@ -76,14 +74,14 @@ const SignInPage: React.FC<SignInPageProps> = ({ location }) => {
       setIsSigningIn(true);
 
       try {
-        const response = (await (auth as MockAuthService | AuthService).signIn({
+        const response = (await auth.signIn({
           email,
           password,
         })) as ApiResponse<JwtToken | ErrorResponse>;
 
         if (response.ok) {
-          navigate('/app/projects');
           SessionStorageHelper.storeJwt(response.data as JwtToken);
+          navigate('/app/projects');
         } else {
           setMessage((response.data as ErrorResponse).message);
         }


### PR DESCRIPTION
- add methods to service resolver class to get existing instance for each service e.g. api service, auth service, stack exchange service. 
- create additional method in session storage helper to update api service header with bearer token when updating `currentJwt`
- remove api prop from panel/card components