### PR TITLE
Fix Instagram username

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -50,7 +50,7 @@ module.exports = Object.freeze({
       /** The website's Facebook username, */
       facebook: '',
       /** The website's Instagram username. */
-      instagram: 'projectunicorn1',
+      instagram: 'projectunic0rn',
       /** The website's Twitter username. */
       twitter: '@projectunicorn2',
       /** The website's LinkedIn username. */


### PR DESCRIPTION
Clicking the Instagram logo in the page footer resolves to a not found page because the Instagram username in the site config file is outdated.