### PR TITLE
change testimonial heading

### DIFF
--- a/src/components/index-page/testimonial/testimonial.tsx
+++ b/src/components/index-page/testimonial/testimonial.tsx
@@ -25,7 +25,7 @@ const Testimonial: React.FC = () => {
 
   return (
     <Wrapper>
-      <Heading>Member Testimonials</Heading>
+      <Heading>What developers say...</Heading>
       <Slider
         autoplay
         autoplaySpeed={5000}


### PR DESCRIPTION
change "Member Testimonials" -> "What developers say...". 

Let me know your thoughts on this change - this feels like it reads better versus using the word testimonial. 

<img width="1440" alt="Screen Shot 2019-12-25 at 7 12 15 AM" src="https://user-images.githubusercontent.com/4195689/71446176-0ebfb600-26e6-11ea-93c2-f0e0c0c29f21.png">