### PR TITLE
Fix projects link in index page

### DIFF
--- a/src/components/index-page/about.tsx
+++ b/src/components/index-page/about.tsx
@@ -1,6 +1,6 @@
+import { Link } from 'gatsby';
 import * as React from 'react';
 
-import { Anchor } from '@components/shared';
 import { iconArrow, goodTeam, bgCurveDesktop, bgCurveMobile } from '@images';
 import { useSiteMetadata } from '@hooks';
 import styled from 'styled-components';
@@ -65,7 +65,7 @@ const SubText = styled.p`
   }
 `;
 
-const Link = styled(Anchor)`
+const StyledLink = styled(Link)`
   align-items: center;
   background: none;
   border-bottom: 0.0625rem solid ${({ theme }) => theme.colors.alternate};
@@ -84,7 +84,7 @@ const LinkImage = styled.img.attrs(() => ({ src: iconArrow, alt: '' }))`
   display: inline-block;
   height: 1.4375em;
   margin: 0;
-  padding: 0 0.4em;
+  padding: 0 0 0 0.4em;
 `;
 
 const ImageWrapper = styled.figure`
@@ -122,14 +122,10 @@ const About: React.FC = () => {
           and build your ideas!
         </SubText>
 
-        <Link
-          href={`${siteMetadata.appUrl}/projects`}
-          external={false}
-          title={`${siteMetadata.title} projects`}
-        >
+        <StyledLink to="/app/projects" title={`${siteMetadata.title} projects`}>
           See projects by members
           <LinkImage />
-        </Link>
+        </StyledLink>
       </Text>
 
       <ImageWrapper>


### PR DESCRIPTION
Previously, the projects link uses a shared `<Anchor />` component which is actually a wrapper for a basic anchor (`<a />`). This change will make use of `<Link />` component from Gatsby to utilize some performance features when linking to internal pages.

> Gatsby’s <Link> component enables linking to internal pages as well as a powerful performance feature called preloading. Preloading is used to prefetch resources so that the resources are fetched by the time the user navigates with this component. We use an IntersectionObserver to fetch a low-priority request when the Link is in the viewport and then use an onMouseOver event to trigger a high-priority request when it is likely that a user will navigate to the requested resource. 
> 
> Source: [Gatsby Link API](https://www.gatsbyjs.org/docs/gatsby-link/)