### PR TITLE
update build definiton to send code coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ node_js:
 
 cache: npm
 
+before_install:
+# install codecov to send code
+# coverage reports
+- npm install codecov -g
+
 jobs:
   include:
     - stage: test
@@ -38,3 +43,6 @@ jobs:
         local-dir: public/
         on:
           tags: true
+
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
   <a href="https://travis-ci.com/projectunic0rn/pub">
     <img src="https://travis-ci.com/projectunic0rn/pub.svg" alt="Travis CI">
   </a>
-
+  <a href="https://codecov.io/gh/projectunic0rn/pub">
+    <img src="https://codecov.io/gh/projectunic0rn/pub/branch/master/graph/badge.svg" />
+  </a>
   <a href="https://projectunicorn.net/">
     <img src="https://img.shields.io/badge/website-https://projectunicorn.net/-blue.svg" alt="Project Unicorn Blog">
   </a>

--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,5 +1,5 @@
 const babelOptions = {
-  presets: ['babel-preset-gatsby'],
+  presets: ['babel-preset-gatsby', '@babel/preset-typescript'],
 };
 
 module.exports = require('babel-jest').createTransformer(babelOptions);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-    '^.+\\.jsx?$': '<rootDir>/jest-preprocess.js',
+    '^.+\\.[jt]sx?$': '<rootDir>/jest-preprocess.js',
   },
   testRegex: '(/__tests__/.*\\.([tj]sx?)|(\\.|/)(test|spec))\\.([tj]sx?)$',
   moduleNameMapper: {
@@ -15,6 +14,17 @@ module.exports = {
   globals: {
     __PATH_PREFIX__: '',
   },
-  testURL: 'http://localhost',
   setupFiles: ['<rootDir>/loadershim.js'],
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx,ts,tsx}',
+    'scripts/**/*.{js,jsx,ts,tsx}',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 2.94,
+      functions: 2.94,
+      lines: 2.94,
+      statements: 2.94,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ignore-path .gitignore . --ext ts --ext tsx --ext js --ext jsx",
     "lint:fix": "eslint --ignore-path .gitignore . --ext ts --ext tsx --ext js --ext jsx --fix",
     "start": "gatsby serve --open",
-    "test": "jest",
+    "test": "jest --coverage",
     "typecheck": "tsc"
   },
   "dependencies": {
@@ -79,7 +79,7 @@
     "eslint-plugin-react-hooks": "2.3.0",
     "husky": "4.0.10",
     "identity-obj-proxy": "3.0.0",
-    "jest": "24.9.0",
+    "jest": "^24.9.0",
     "lint-staged": "10.0.0",
     "prettier": "1.19.1",
     "react-is": "16.12.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint --ignore-path .gitignore . --ext ts --ext tsx --ext js --ext jsx --fix",
     "start": "gatsby serve --open",
     "test": "jest --coverage",
+    "test:watch": "jest --coverage --watch",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "prettier": "1.19.1",
     "react-is": "16.12.0",
     "react-test-renderer": "16.12.0",
-    "ts-jest": "24.3.0",
     "typescript": "3.7.5"
   }
 }


### PR DESCRIPTION
This PR integrates Codecov into the pub repo. Here are a list of changes

- Update Travis build file to install codecov and run codecov once build completes successfully to upload coverage reports. 
- Remove `^.+\\.tsx?$': 'ts-jest'` transform rule from jest.config.js. Instead use `'@babel/preset-typescript'` and update remaining transform rule to include typescript files. This transform was causing syntax errors when running unit tests. Also removed ts-jest package. 
- add jest config option to collect coverage from all files under `src` and `scripts` directory
- add jest config option to set global coverage threshold to 2.94% for all coverage categories (e.g. branches, statements, functions, lines)
- remove testUrl option since it already defaults to `http://localhost`, [jest doc](https://jestjs.io/docs/en/configuration#testurl-string)
- update test script in package.json to include --coverage flag
- add `test:watch` to package.json to easily run tests while developing