### PR TITLE
Update Jest configuration file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,6 +29,10 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',
     'scripts/**/*.{js,jsx,ts,tsx}',
+    '!src/**/index.ts',
+    '!src/**/*.d.ts',
+    '!src/**/types/*.ts',
+    '!src/mocks/**/*.{ts,tsx}',
   ],
   coverageThreshold: {
     global: {

--- a/src/components/shared/__tests__/message.spec.tsx
+++ b/src/components/shared/__tests__/message.spec.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import Message, { MessageVariant } from '../message';
+import { MockThemeProvider } from '@mocks';
+import { theme } from '@styles';
+
+test('should have correct style depending on variant', () => {
+  const message = (variant?: MessageVariant) => (
+    <MockThemeProvider>
+      <Message variant={variant} value="My Message" />
+    </MockThemeProvider>
+  );
+
+  const { getByText, rerender } = render(message());
+
+  expect(getByText('My Message')).toHaveStyle(`color: ${theme.colors.base}`);
+
+  rerender(message('error'));
+  expect(getByText('My Message')).toHaveStyle(`color: red`);
+
+  rerender(message('success'));
+  expect(getByText('My Message')).toHaveStyle(`color: green`);
+});

--- a/src/components/shared/message.tsx
+++ b/src/components/shared/message.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 
-type MessageVariant = 'error' | 'success' | 'default';
+export type MessageVariant = 'error' | 'success' | 'default';
 
 interface MessageProps {
   value: string;

--- a/src/utils/__tests__/string-utils.spec.ts
+++ b/src/utils/__tests__/string-utils.spec.ts
@@ -68,6 +68,7 @@ describe('styleLengths', () => {
   test('return correct unit depending on input type', () => {
     const expected = '10px';
 
+    expect(styleLengths()).toBe('0px');
     expect(styleLengths(10)).toBe(expected);
     expect(styleLengths('10px')).toBe(expected);
     expect(styleLengths(10, 'px')).toBe(expected);


### PR DESCRIPTION
This change will tell Jest to not collect coverage information from:

- Barrel files (index.ts)
- Type definitions
- Files that export TypeScript types
- Mocks

**Notes**:

- Add one (1) test and update another test to offset coverage decrease due to removal of the above files