### PR TITLE
Add ErrorBoundary component

### DIFF
--- a/src/components/shared/__tests__/error-boundary.spec.tsx
+++ b/src/components/shared/__tests__/error-boundary.spec.tsx
@@ -10,7 +10,7 @@ const ThrowError = () => {
   throw new Error('test/error-code');
 };
 
-test('renders children if there are no expections', () => {
+test('renders children if there are no exceptions', () => {
   const { getByText, queryByText } = render(
     <ErrorBoundary onError={jest.fn()} component={<ErrorComponent />}>
       yey!

--- a/src/components/shared/__tests__/error-boundary.spec.tsx
+++ b/src/components/shared/__tests__/error-boundary.spec.tsx
@@ -1,0 +1,40 @@
+import React, { FC } from 'react';
+import { render } from '@testing-library/react';
+
+import ErrorBoundary from '../error-boundary';
+import { noop } from '@utils';
+
+const ErrorComponent: FC = () => <div>Oh noes!</div>;
+
+const ThrowError = () => {
+  throw new Error('test/error-code');
+};
+
+test('renders children if there are no expections', () => {
+  const { getByText, queryByText } = render(
+    <ErrorBoundary onError={jest.fn()} component={<ErrorComponent />}>
+      yey!
+    </ErrorBoundary>,
+  );
+
+  expect(getByText(/yey/i)).toBeInTheDocument();
+  expect(queryByText(/oh noes/i)).toBeNull();
+});
+
+test('renders the error component when exceptions are caught', () => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(noop);
+  const onErrorSpy = jest.fn(noop);
+
+  const { getByText, queryByText } = render(
+    <ErrorBoundary onError={onErrorSpy} component={<ErrorComponent />}>
+      <ThrowError />
+      yey!
+    </ErrorBoundary>,
+  );
+
+  expect(getByText(/oh noes/i)).toBeInTheDocument();
+  expect(queryByText(/yey/i)).toBeNull();
+  expect(onErrorSpy).toHaveBeenCalledTimes(1);
+
+  consoleErrorSpy.mockRestore();
+});

--- a/src/components/shared/error-boundary.tsx
+++ b/src/components/shared/error-boundary.tsx
@@ -1,0 +1,40 @@
+import { ErrorInfo, ReactNode, Component } from 'react';
+
+type ErrorBoundaryProps = {
+  /**
+   * onError accepts an Error object and an ErrorInfo object for additional
+   * operations, e.g. clean up, graceful navigation, error reporting to a remote
+   * server, etc.
+   */
+  onError: (error: Error, info: ErrorInfo) => void;
+  /** component will be rendered when an expection is caught. */
+  component: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+/**
+ * ErrorBoundary renders an error page component if any descendant component
+ * throws an exception. Otherwise, it renders the children.
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public readonly state: Readonly<ErrorBoundaryState> = {
+    hasError: false,
+  };
+
+  public componentDidCatch(error: Error, info: ErrorInfo) {
+    this.setState({ hasError: true });
+    this.props.onError(error, info);
+  }
+
+  public render() {
+    const { component, children } = this.props;
+    const { hasError } = this.state;
+
+    return hasError ? component : children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/shared/error-boundary.tsx
+++ b/src/components/shared/error-boundary.tsx
@@ -31,9 +31,8 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   public render() {
     const { component, children } = this.props;
-    const { hasError } = this.state;
 
-    return hasError ? component : children;
+    return this.state.hasError ? component : children;
   }
 }
 

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,5 +1,6 @@
 export { default as Anchor } from './anchor';
 export { default as Container } from './container';
+export { default as ErrorBoundary } from './error-boundary';
 export { default as Footer } from './footer';
 export { default as Seo } from './seo';
 export { default as SocialIcon } from './social-icon';

--- a/src/components/shared/layout/error-component.tsx
+++ b/src/components/shared/layout/error-component.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'gatsby';
+import React, { FC, Fragment } from 'react';
+import styled from 'styled-components';
+
+import { Container, PageTitle, Seo } from '@components/shared';
+import { useSiteMetadata } from '@hooks';
+
+const Text = styled.p`
+  text-align: center;
+  line-height: 1.6;
+
+  a {
+    color: ${({ theme }) => theme.colors.base};
+  }
+`;
+
+const ErrorComponent: FC = () => {
+  const siteMetadata = useSiteMetadata();
+
+  return (
+    <Fragment>
+      <Seo
+        title="Something bad happened"
+        description="Something bad happened"
+      />
+
+      <Container>
+        <PageTitle>Something bad happened</PageTitle>
+
+        <Text>
+          Please return{' '}
+          <Link to="/" title={`${siteMetadata.title} home page`}>
+            home
+          </Link>{' '}
+          or use the menu to navigate to a different page.
+        </Text>
+      </Container>
+    </Fragment>
+  );
+};
+
+export default ErrorComponent;

--- a/src/components/shared/layout/layout.tsx
+++ b/src/components/shared/layout/layout.tsx
@@ -9,7 +9,9 @@ import OffCanvas from 'react-aria-offcanvas';
 import { ThemeProvider } from 'styled-components';
 
 import { defaultNavItems } from './default-nav-items';
+import ErrorComponent from './error-component';
 import {
+  ErrorBoundary,
   Seo,
   Navigation,
   NavItem,
@@ -135,7 +137,15 @@ const Layout: FC<LayoutProps> = ({ children, navItems = defaultNavItems }) => {
               isSidebarOpen={state.isSidebarOpen}
               openSidebar={setOpen(true)}
             />
-            {children}
+
+            <ErrorBoundary
+              // eslint-disable-next-line no-console
+              onError={console.error}
+              component={<ErrorComponent />}
+            >
+              {children}
+            </ErrorBoundary>
+
             <Footer />
           </div>
 

--- a/src/utils/general-utils.ts
+++ b/src/utils/general-utils.ts
@@ -1,4 +1,5 @@
 /** No operation */
-export const noop = () => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const noop = (..._args: unknown[]) => {
   return;
 };


### PR DESCRIPTION
**Notes**:

- **Add `ErrorBoundary` component**
- Add two (2) tests for `ErrorBoundary`
- Add an `ErrorComponent` to `Layout` that renders a generic error component when the error boundary catches any unhanded exception thrown in any of `Layout`'s descendants.
- Update `noop` utility to be variadic.