### PR TITLE
send remaining user values with update user request

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@types/lodash": "^4.14.149",
     "gatsby": "2.20.20",
     "gatsby-image": "2.3.2",
     "gatsby-plugin-alias-imports": "1.0.5",
@@ -43,6 +44,7 @@
     "gatsby-transformer-remark": "2.7.1",
     "gatsby-transformer-sharp": "2.4.4",
     "gatsby-transformer-yaml": "2.3.1",
+    "lodash": "^4.17.15",
     "prismjs": "1.20.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",

--- a/src/api/types/user-technology.ts
+++ b/src/api/types/user-technology.ts
@@ -1,5 +1,5 @@
 export interface UserTechnology {
   name: string;
   userId: string;
-  id: string;
+  id?: string;
 }

--- a/src/components/shared/__tests__/account-settings.spec.tsx
+++ b/src/components/shared/__tests__/account-settings.spec.tsx
@@ -98,8 +98,24 @@ describe('test account settings component', () => {
     const usernameInput = await waitFor(() => getByLabelText('Username'));
     fireEvent.change(usernameInput, { target: { value: 'newUsername' } });
     const updatedUsername = await waitFor(() => getByLabelText('Username'));
-    const inputElemenet = updatedUsername as HTMLInputElement;
+    const inputElement = updatedUsername as HTMLInputElement;
     // Assert
-    expect(inputElemenet.value).toBe('newUsername');
+    expect(inputElement.value).toBe('newUsername');
+  });
+
+  test('bio is updated successfully', async () => {
+    // Arrange
+    const { getByLabelText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const bioInput = await waitFor(() => getByLabelText('Bio'));
+    fireEvent.change(bioInput, { target: { value: 'new bio' } });
+    const updatedUsername = await waitFor(() => getByLabelText('Bio'));
+    const inputElement = updatedUsername as HTMLInputElement;
+    // Assert
+    expect(inputElement.value).toBe('new bio');
   });
 });

--- a/src/components/shared/__tests__/account-settings.spec.tsx
+++ b/src/components/shared/__tests__/account-settings.spec.tsx
@@ -114,7 +114,7 @@ describe('test account settings component', () => {
     const bioInput = await waitFor(() => getByLabelText('Bio'));
     fireEvent.change(bioInput, { target: { value: 'new bio' } });
     const updatedUsername = await waitFor(() => getByLabelText('Bio'));
-    const inputElement = updatedUsername as HTMLInputElement;
+    const inputElement = updatedUsername as HTMLTextAreaElement;
     // Assert
     expect(inputElement.value).toBe('new bio');
   });

--- a/src/components/shared/form/__tests__/technologies-select.spec.tsx
+++ b/src/components/shared/form/__tests__/technologies-select.spec.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { MockThemeProvider } from '@mocks';
+import { TechnologiesSelect } from '../controls';
+
+test('render TechnologiesSelect select component', async () => {
+  // Arrange
+  const mockSetError = () => {};
+  const mockSetTechnologies = () => {};
+  const { findByText } = render(
+    <MockThemeProvider>
+      <TechnologiesSelect
+        name="technologies"
+        id="technologies"
+        setError={mockSetError}
+        initialValues={[]}
+        setTechnologies={mockSetTechnologies}
+      />
+    </MockThemeProvider>,
+  );
+
+  // Act
+  const select = await waitFor(() => findByText('Select...'));
+
+  // Assert
+  expect(select).toBeInTheDocument();
+  expect(select).toBeDefined();
+  expect(select).toBeVisible();
+});

--- a/src/components/shared/form/controls/technologies-select.tsx
+++ b/src/components/shared/form/controls/technologies-select.tsx
@@ -80,14 +80,15 @@ export const TechnologiesSelect: FC<TechnologiesSelectProps> = ({
   const stackExchange = ServiceResolver.stackExchangeResolver();
 
   const handleSelectChange = (e: ValueType<OptionType>) => {
-    let technologies: ProjectTechnology[];
+    let technologies: string[];
 
     if (Array.isArray(e)) {
-      technologies = e.map((v) => ({ name: v.value, projectId: '' }));
-      setTechnologies(e.map((v) => v.value));
+      technologies = e.map((v) => v.value);
     } else {
       technologies = [];
     }
+
+    setTechnologies(technologies);
 
     if (formInputs && setFormInputs) {
       setFormInputs({


### PR DESCRIPTION
Main goal was to correct the data being sent as part of the update user request. Currently the data is only being sent with the partial user object so updated logic to include the entire user object while still including updated fields. 
```
const updatedUser: User = {
    ...user,
    username,
    bio,
    technologies,
};
```

Other changes 
- Add lodash package to use debounce function, helps limit api calls when validating username on account settings page
- re-used code from sign-up component to highlight invalid username
 