### PR TITLE
Fix profile page and settings page styles

### DIFF
--- a/src/components/shared/containers/base-container.tsx
+++ b/src/components/shared/containers/base-container.tsx
@@ -1,17 +1,16 @@
-import React, { FC } from 'react';
 import styled from 'styled-components';
 
-export const BaseContainerHtml = styled.div`
+type BaseContainerProps = {
+  hasBorder?: boolean;
+};
+
+export const BaseContainer = styled.div<BaseContainerProps>`
   display: flex;
   flex-direction: column;
   margin: 0 auto;
 
   @media screen and (min-width: ${({ theme }) => theme.sizes.width.small}) {
-    border: 1px solid lightgray;
+    border: ${({ hasBorder }) => (hasBorder ? '1px solid lightgray' : 'none')};
     flex-direction: row;
   }
 `;
-
-export const BaseContainer: FC = ({ children }) => (
-  <BaseContainerHtml>{children}</BaseContainerHtml>
-);

--- a/src/components/shared/containers/main-content.tsx
+++ b/src/components/shared/containers/main-content.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const MainContent = styled.div`
-  margin: 20px;
-  font-size: 16px;
+  margin: 1.25em;
+  flex: 0.7;
+  font-size: 1em;
 `;

--- a/src/components/shared/containers/profile-container.tsx
+++ b/src/components/shared/containers/profile-container.tsx
@@ -20,18 +20,17 @@ type ProfileContainerProps = {
 };
 
 const Image = styled.img`
-  border-radius: 100px;
-  max-width: 50%;
+  border-radius: 50%;
+  max-width: 40%;
   margin-bottom: 0;
 `;
 
 const Wrapper = styled.div`
-  padding: ${({ theme }) => theme.boxes.padding.section.smallTop};
-  width: 100%;
-  min-height: 50vh;
+  margin: 0 auto;
+  padding: 0;
 
-  @media screen and (max-width: ${({ theme }) => theme.sizes.width.small}) {
-    padding: 0;
+  @media screen and (min-width: ${({ theme }) => theme.sizes.width.small}) {
+    padding: ${({ theme }) => theme.boxes.padding.section.smallTop};
   }
 `;
 
@@ -77,28 +76,24 @@ export const ProfileContainer: FC<ProfileContainerProps> = ({ id }) => {
 
       {!isLoading && user && (
         <BaseContainer>
-          <ContainerSidePanel style={{ padding: '20px ' }}>
+          <ContainerSidePanel>
             <Summary>
               <Image
                 src={user.profilePictureUrl || defaultProfileImage}
                 alt="Profile Picture"
               />
               <Summary>{user.username}</Summary>
+              {UserAuthHelper.isUserAuthenticated() && (
+                <Button as={Link} to="/settings">
+                  Edit Profile
+                </Button>
+              )}
             </Summary>
-            {UserAuthHelper.isUserAuthenticated() && (
-              <Fragment>
-                <br />
-                <Link to="/settings">
-                  <Button>Edit Profile</Button>
-                </Link>
-              </Fragment>
-            )}
           </ContainerSidePanel>
           <MainContent>
             {user.bio && (
               <Fragment>
                 <FormLabel>Bio</FormLabel>
-                <br />
                 <p>{user.bio}</p>
               </Fragment>
             )}
@@ -106,12 +101,13 @@ export const ProfileContainer: FC<ProfileContainerProps> = ({ id }) => {
             {user.technologies && (
               <Fragment>
                 <FormLabel>Technologies</FormLabel>
-                <br />
-                {user.technologies.map((t) => (
-                  <ProfileTechPill data-testid="technology" key={t.name}>
-                    {t.name}
-                  </ProfileTechPill>
-                ))}
+                <div style={{ marginTop: '0.4em' }}>
+                  {user.technologies.map((t) => (
+                    <ProfileTechPill data-testid="technology" key={t.name}>
+                      {t.name}
+                    </ProfileTechPill>
+                  ))}
+                </div>
               </Fragment>
             )}
           </MainContent>

--- a/src/components/shared/containers/settings-container.tsx
+++ b/src/components/shared/containers/settings-container.tsx
@@ -49,7 +49,7 @@ export const SettingsContainer: FC<SettingsContainerProps> = ({
         </Ribbon>
       )}
 
-      {!isLoading && <BaseContainer>{children}</BaseContainer>}
+      {!isLoading && <BaseContainer hasBorder>{children}</BaseContainer>}
     </Wrapper>
   );
 };

--- a/src/components/shared/side-panels/container-side-panel.tsx
+++ b/src/components/shared/side-panels/container-side-panel.tsx
@@ -1,16 +1,20 @@
 import styled from 'styled-components';
 
 export const ContainerSidePanel = styled.div`
-  flex: 1;
-  border-right: 1px solid lightgray;
+  flex: 0.3;
+  border: none;
   padding-top: 2em;
+
+  @media screen and (min-width: ${({ theme }) => theme.sizes.width.small}) {
+    border-right: 1px solid lightgray;
+  }
 `;
 
 export const Summary = styled.div`
   color: black;
   text-align: center;
   width: 100%;
-  margin: 0 auto;
+  margin: 0 auto 1em;
 `;
 
 export const Image = styled.img`


### PR DESCRIPTION
The profile/settings pages displays okay when there's content on the right panel (i.e. bio, technologies) but if there's none, it will shrink to minimum length.

Regarding the border: I forgot to add back the boolean prop that sets the border style on the base container.

I also did some minor style tweaks to be consistent with the design.