### PR TITLE
Fix profile page wrapper style

### DIFF
--- a/src/components/shared/containers/profile-container.tsx
+++ b/src/components/shared/containers/profile-container.tsx
@@ -28,6 +28,7 @@ const Image = styled.img`
 const Wrapper = styled.div`
   margin: 0 auto;
   padding: 0;
+  min-height: 50vh;
 
   @media screen and (min-width: ${({ theme }) => theme.sizes.width.small}) {
     padding: ${({ theme }) => theme.boxes.padding.section.smallTop};


### PR DESCRIPTION
This will add back a minimum height to the wrapper so the loading spinner doesn't overlap the footer component.