### PR TITLE
create auth context to share auth state across components via useCont…

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,9 @@
-require('prismjs/themes/prism.css');
-require('./src/styles/global.css');
+import React from 'react';
+import { AuthProvider } from '@contexts';
+import './src/styles/global.css';
+import 'prismjs/themes/prism.css';
 
-exports.shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
+export const shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
   if (prevRouterProps.location.pathname === routerProps.location.pathname) {
     return false;
   }
@@ -10,3 +12,7 @@ exports.shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
 
   return false;
 };
+
+export const wrapRootElement = ({ element }) => (
+  <AuthProvider>{element}</AuthProvider>
+);

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -86,6 +86,7 @@ module.exports = {
         alias: {
           '@api': 'src/api',
           '@components': 'src/components',
+          '@contexts': 'src/contexts',
           '@helpers': 'src/helpers',
           '@hooks': 'src/hooks',
           '@images': 'src/images',

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/__mocks__/file-mock.js',
     '^@components/(.*)': '<rootDir>/src/components/$1',
+    '^@contexts': '<rootDir>/src/contexts/index',
     '^@hooks/(.*)': '<rootDir>/src/hooks/$1',
     '^@hooks': '<rootDir>/src/hooks/index',
     '^@utils/(.*)': '<rootDir>/src/utils/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/src/api/http-client.ts
+++ b/src/api/http-client.ts
@@ -2,6 +2,8 @@ export class HttpClient {
   public static async makeRequest(request: Request): Promise<unknown> {
     const response = await fetch(request);
 
+    // TODO: If 401 - sign out user with
+    // message that session has expired.
     if (!response.ok && response.type) {
       throw new Error(response.statusText);
     }

--- a/src/components/shared/__tests__/navigation.spec.tsx
+++ b/src/components/shared/__tests__/navigation.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Navigation } from '../navigation';
+import { render, waitFor } from '@testing-library/react';
+import { AuthProvider } from '@contexts';
+import { MockThemeProvider } from '@mocks';
+import { SessionStorageHelper } from '@helpers';
+import { signInResponse, user } from '@mocks/responses';
+import { JwtToken } from '@api';
+import { defaultNavItems } from '../layout/default-nav-items';
+
+describe('navigation', () => {
+  test('profile image of authenticated user is displayed on nav', async () => {
+    // Arrange
+    const expectedAvatar = user.data.profilePictureUrl;
+    SessionStorageHelper.storeJwt(signInResponse.data as JwtToken);
+    const { getByAltText } = render(
+      <AuthProvider>
+        <MockThemeProvider>
+          <Navigation
+            isAtTop={true}
+            isVisible={true}
+            isSidebarOpen={false}
+            openSidebar={jest.fn()}
+            navItems={defaultNavItems}
+          ></Navigation>
+        </MockThemeProvider>
+      </AuthProvider>,
+    );
+    // Act
+    const navAvatar = (await waitFor(() =>
+      getByAltText('profile image'),
+    )) as HTMLImageElement;
+    // Assert
+    expect(navAvatar).toBeDefined();
+    expect(navAvatar).toBeVisible();
+    expect(navAvatar.src).toBe(expectedAvatar);
+  });
+});

--- a/src/components/shared/containers/account-settings.tsx
+++ b/src/components/shared/containers/account-settings.tsx
@@ -55,6 +55,7 @@ export const AccountSettings: FC = () => {
   const [bio, setBio] = useState('');
   const [technologies, setTechnologies] = useState<UserTechnology[]>([]);
 
+  // TODO: Read authentication state via Auth Context
   useEffect(() => {
     const api = ServiceResolver.apiResolver();
 

--- a/src/components/shared/form/sign-in.tsx
+++ b/src/components/shared/form/sign-in.tsx
@@ -1,9 +1,9 @@
 import { Link, navigate } from 'gatsby';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState, useContext } from 'react';
 import styled from 'styled-components';
 
 import { ApiButton } from '../buttons/api-button';
-import { ApiResponse, ErrorResponse, JwtToken, ServiceResolver } from '@api';
+import { ApiResponse, ErrorResponse, JwtToken } from '@api';
 import { useSiteMetadata } from '@hooks';
 import {
   FormLabel,
@@ -12,7 +12,7 @@ import {
   ButtonWrapper,
 } from '@components/shared/form/controls';
 import { Form } from '@components/shared/form';
-import { SessionStorageHelper } from '@helpers';
+import { AuthContext } from '@contexts';
 
 const Wrapper = styled.section`
   background-color: ${({ theme }) => theme.colors.section};
@@ -43,7 +43,7 @@ interface SignInFormProps {
 
 export const SignInForm: FC<SignInFormProps> = ({ location }) => {
   const siteMetadata = useSiteMetadata();
-
+  const authContext = useContext(AuthContext);
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [message, setMessage] = useState<string>('');
@@ -55,21 +55,18 @@ export const SignInForm: FC<SignInFormProps> = ({ location }) => {
   }, [location.state]);
 
   const handleClick = async () => {
-    const auth = ServiceResolver.authResolver();
-
     if (email === '' || password === '') {
       setMessage('Invalid email or password');
       return;
     }
 
     try {
-      const response = (await auth.signIn({
+      const response = (await authContext.signIn?.({
         email,
         password,
       })) as ApiResponse<JwtToken | ErrorResponse>;
 
       if (response.ok) {
-        SessionStorageHelper.storeJwt(response.data as JwtToken);
         navigate('/projects/');
       } else {
         setMessage((response.data as ErrorResponse).message);

--- a/src/components/shared/layout/default-nav-items.tsx
+++ b/src/components/shared/layout/default-nav-items.tsx
@@ -2,15 +2,10 @@ import { Link, navigate } from 'gatsby';
 import React from 'react';
 
 import { NavButton, NavItem, Show, Profile } from '../navigation';
-import { SessionStorageHelper } from '@helpers';
 import { defaultProfileImage } from '@images';
+import { noop } from '@utils';
 
 const handleNavigate = (to: string) => () => navigate(to);
-
-const signOut = () => {
-  SessionStorageHelper.deleteJwt();
-  navigate('/');
-};
 
 export const defaultNavItems: NavItem[] = [
   {
@@ -38,7 +33,8 @@ export const defaultNavItems: NavItem[] = [
     show: Show.AuthOnly,
   },
   {
-    item: <Profile content={defaultProfileImage} signOut={signOut} />,
+    // item gets redefined in navigation
+    item: <Profile content={defaultProfileImage} signOut={noop} />,
     key: 'user-avatar-dropdown',
     show: Show.AuthOnly,
   },

--- a/src/components/shared/layout/layout.tsx
+++ b/src/components/shared/layout/layout.tsx
@@ -109,6 +109,14 @@ const Layout: FC<LayoutProps> = ({ children, navItems = defaultNavItems }) => {
     dispatch({ type: AUTH_IS, payload: { isUserAuthenticated } });
   }, []);
 
+  // TODO: Possibly mutation to be added to useEffects
+  /*
+    https://reactjs.org/docs/hooks-reference.html#useeffect
+    Mutations, subscriptions, timers, logging, and other side effects are
+    not allowed inside the main body of a function component (referred to
+    as React’s render phase). Doing so will lead to confusing bugs and
+    inconsistencies in the UI.
+  */
   navItems = navItems.filter(({ show }) => {
     switch (show) {
       case Show.Always:

--- a/src/components/shared/navigation/navigation.tsx
+++ b/src/components/shared/navigation/navigation.tsx
@@ -1,8 +1,11 @@
-import React, { FC } from 'react';
+import { navigate } from 'gatsby';
+import React, { FC, useContext } from 'react';
 import styled from 'styled-components';
 
 import Brand from './brand';
 import { NavItem } from './nav-item';
+import { Profile } from '.';
+import { AuthContext } from '@contexts';
 
 interface OwnProps {
   isAtTop: boolean;
@@ -99,10 +102,29 @@ const Navigation: FC<NavigationProps> = ({
   navItems = [],
   openSidebar,
 }) => {
+  const authContext = useContext(AuthContext);
+
+  const signOut = () => {
+    if (authContext.signOut == undefined) {
+      return;
+    }
+    authContext.signOut();
+    navigate('/');
+  };
+
+  const setAvatar = (avatar: string) => {
+    navItems.map((navItem) => {
+      if (navItem.key == 'user-avatar-dropdown') {
+        navItem.item = <Profile content={avatar} signOut={signOut} />;
+      }
+    });
+  };
+
+  setAvatar(authContext.avatar);
+
   return (
     <Wrapper isAtTop={isAtTop} isVisible={isAtTop || isVisible}>
       <Brand />
-
       <Menu>
         {navItems.map(({ item, key }) => (
           <MenuItem key={'menubar' + key}>{item}</MenuItem>

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -30,7 +30,7 @@ export const AuthContext = React.createContext(defaultAuthContextState);
 export const AuthConsumer = AuthContext.Consumer;
 
 export const AuthProvider: FC = (props) => {
-  const [authContextState, setAuthContextState] = useState<AuthContextState>(
+  const [authContextState, setAuthContextState] = useState(
     defaultAuthContextState,
   );
 

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,0 +1,105 @@
+import React, { FC, useState, useEffect } from 'react';
+import {
+  User,
+  SignIn,
+  ServiceResolver,
+  ApiResponse,
+  JwtToken,
+  ErrorResponse,
+} from '@api';
+import { defaultProfileImage } from '@images';
+import { SessionStorageHelper, UserAuthHelper } from '@helpers';
+
+interface AuthContextState {
+  authenticated: boolean;
+  avatar: string;
+  member?: User;
+  signIn?: (
+    credentials: SignIn,
+  ) => Promise<ApiResponse<JwtToken | ErrorResponse>>;
+  signOut?: () => void;
+}
+
+const defaultAuthContextState: AuthContextState = {
+  authenticated: false,
+  avatar: defaultProfileImage,
+  member: undefined,
+};
+
+export const AuthContext = React.createContext(defaultAuthContextState);
+export const AuthConsumer = AuthContext.Consumer;
+
+export const AuthProvider: FC = (props) => {
+  const [authContextState, setAuthContextState] = useState<AuthContextState>(
+    defaultAuthContextState,
+  );
+
+  const getUser = async (): Promise<ApiResponse<User | ErrorResponse>> => {
+    const userId = UserAuthHelper.getUserId();
+    const api = ServiceResolver.apiResolver();
+    const response = (await api.getUser(userId)) as ApiResponse<
+      User | ErrorResponse
+    >;
+    return response;
+  };
+
+  const signIn = async (
+    credentials: SignIn,
+  ): Promise<ApiResponse<JwtToken | ErrorResponse>> => {
+    const auth = ServiceResolver.authResolver();
+    const response = (await auth.signIn(credentials)) as ApiResponse<
+      JwtToken | ErrorResponse
+    >;
+
+    if (response.ok) {
+      SessionStorageHelper.storeJwt(response.data as JwtToken);
+      const userResponse = (await getUser()) as ApiResponse<
+        User | ErrorResponse
+      >;
+      if (userResponse.ok) {
+        const user = userResponse.data as User;
+        const authContextState = {
+          authenticated: true,
+          avatar: user.profilePictureUrl || defaultProfileImage,
+          member: user,
+          signIn: signIn,
+        };
+
+        setAuthContextState(authContextState);
+      }
+    }
+    return response;
+  };
+
+  const signOut = () => {
+    SessionStorageHelper.deleteJwt();
+  };
+
+  useEffect(() => {
+    const initializeAuthContext = async () => {
+      const isUserAuthenticated = UserAuthHelper.isUserAuthenticated();
+      const defaultAuthContextState: AuthContextState = {
+        authenticated: isUserAuthenticated,
+        avatar: defaultProfileImage,
+        member: undefined,
+      };
+
+      if (isUserAuthenticated) {
+        const response = await getUser();
+        const user = response.data as User;
+        defaultAuthContextState.member = response.data as User;
+        defaultAuthContextState.avatar =
+          user.profilePictureUrl || defaultProfileImage;
+      }
+      setAuthContextState(defaultAuthContextState);
+    };
+
+    initializeAuthContext();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ ...authContextState, signIn, signOut }}>
+      {props.children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './auth-context';

--- a/src/mocks/responses/user.ts
+++ b/src/mocks/responses/user.ts
@@ -5,7 +5,8 @@ export const user: ApiResponse<User> = {
   data: {
     id: '04200724-b54c-4fc1-84c7-187475f2f68d',
     username: 'unicorn92',
-    profilePictureUrl: '',
+    profilePictureUrl:
+      'https://avatars.slack-edge.com/2019-12-15/861431544242_d975c9e1b069764d81a6_192.png',
     bio:
       'I am a specialized unicorn developer who is well experienced in HTML, CSS, Python, PHP, React, JavaScript, and TypeScript. I am open to learning new tech and languages.',
     technologies: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
       "@api/*": ["./src/api/*"],
       "@components": ["./src/components/index"],
       "@components/*": ["./src/components/*"],
+      "@contexts": ["./src/contexts/index"],
+      "@contexts/*": ["./src/contexts/*"],
       "@helpers": ["./src/helpers/index"],
       "@helpers/*": ["./src/helpers/*"],
       "@hooks": ["./src/hooks/index"],


### PR DESCRIPTION
The goal of this PR is to correctly display the avatar on the nav once successfully authenticated. 

Notes
- To read authentication status across the application inside deeply nested components I am using react context and created auth-context.tsx. In this context component I fetch the user on successful authentication - store the user data in memory, store avatar aka profile picture, and authentication status. Inside navigation.tsx I use the AuthContext to read and update the avatar if the profile item is present. 
- Added TODO notes which relate to future changes that should be made or considered. A couple include - resolving the 401 issue once token is expired (currently working on) and we can update logic in account-settings.tsx to replace the api call with useContext to fetch user profile data.
- Added alias for contexts directory. 
- Moved majority of authentication logic (sign in, sign out) to auth context. 
- update gatsby-browser.js to wrap app with AuthProvider, needed to access auth context state in deeply nested components via useContext hook.

References
- [React Context](https://reactjs.org/docs/context.html)
