### PR TITLE
Account tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.5",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/src/api/api-service.ts
+++ b/src/api/api-service.ts
@@ -1,5 +1,12 @@
 import { HttpClient } from './http-client';
-import { Feedback, ProjectUser, Project, User, Username } from './types';
+import {
+  Feedback,
+  ProjectUser,
+  Project,
+  User,
+  Username,
+  ChangePassword,
+} from './types';
 import { SessionStorageHelper } from '@helpers';
 
 export class ApiService {
@@ -81,6 +88,14 @@ export class ApiService {
       `${this.apiEndpoint}/users`,
       this.headers,
       user,
+    );
+  }
+
+  public async changePassword(changePassword: ChangePassword) {
+    return await HttpClient.post(
+      `${this.apiEndpoint}/auth/change-password`,
+      this.headers,
+      changePassword,
     );
   }
 }

--- a/src/api/types/change-password.ts
+++ b/src/api/types/change-password.ts
@@ -1,0 +1,5 @@
+export interface ChangePassword {
+  oldPassword: string;
+  newPassword: string;
+  confirmedNewPassword: string;
+}

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -13,3 +13,4 @@ export * from './user-validation';
 export * from './user';
 export * from './user-technology';
 export * from './username';
+export * from './change-password';

--- a/src/api/types/user.ts
+++ b/src/api/types/user.ts
@@ -9,6 +9,6 @@ export interface User {
   profilePictureUrl?: string;
   gitHubUsername?: string;
   bio: string;
-  technologies?: UserTechnology[];
+  technologies: UserTechnology[];
   projects?: Project[];
 }

--- a/src/components/account/__tests__/account-settings.spec.tsx
+++ b/src/components/account/__tests__/account-settings.spec.tsx
@@ -1,0 +1,228 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MockThemeProvider } from '@mocks';
+import { AccountSettings } from '../account-settings';
+import { MockAuthService } from '@mocks';
+import { SignIn, JwtToken } from '@api';
+import { SessionStorageHelper } from '@helpers';
+
+describe('test account settings component', () => {
+  // Test suite setup
+  beforeEach(() => {
+    // emulate existing user login
+    const credentials: SignIn = {
+      email: 'email@email.com',
+      password: 'password',
+    };
+
+    const response = new MockAuthService().signIn(credentials);
+    SessionStorageHelper.storeJwt(response.data as JwtToken);
+  });
+
+  test('edit profile tab displays username input with label', () => {
+    // Arrange
+    const { getByLabelText, getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Edit Profile');
+    fireEvent.click(tab);
+    const text = getByLabelText('Username');
+    // Assert
+    expect(text).toBeDefined();
+    expect(text).toBeVisible();
+  });
+
+  test('edit profile tab displays bio with label', () => {
+    // Arrange
+    const { getByLabelText, getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Edit Profile');
+    fireEvent.click(tab);
+    const text = getByLabelText('Bio');
+    // Assert
+    expect(text).toBeDefined();
+    expect(text).toBeVisible();
+  });
+
+  test('edit profile tab displays technologies with label', () => {
+    // Arrange
+    const { getByLabelText, getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Edit Profile');
+    fireEvent.click(tab);
+    const text = getByLabelText('Technologies');
+    // Assert
+    expect(text).toBeDefined();
+    expect(text).toBeVisible();
+  });
+
+  test('current menu item is emphasized', async () => {
+    // Arrange
+    // Act
+    // Assert
+  });
+
+  test('edit user api is called successfully when saved from edit profile tab', async () => {
+    // Arrange
+    const { getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Edit Profile');
+    fireEvent.click(tab);
+    const saveButton = getByText('Save');
+    fireEvent.click(saveButton);
+    const banner = await waitFor(() => getByText('Settings saved'));
+    // Assert
+    expect(banner).toBeDefined();
+    expect(banner).toBeVisible();
+  });
+
+  test('username is updated successfully from edit profile tab', () => {
+    // Arrange
+    const { getByLabelText, getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Edit Profile');
+    fireEvent.click(tab);
+    const usernameInput = getByLabelText('Username');
+    fireEvent.change(usernameInput, { target: { value: 'newUsername' } });
+    const updatedUsername = getByLabelText('Username');
+    const inputElement = updatedUsername as HTMLInputElement;
+    // Assert
+    expect(inputElement.value).toBe('newUsername');
+  });
+
+  test('bio is updated successfully from edit profile tab', () => {
+    // Arrange
+    const { getByLabelText, getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Edit Profile');
+    fireEvent.click(tab);
+    const bioInput = getByLabelText('Bio');
+    fireEvent.change(bioInput, { target: { value: 'new bio' } });
+    const updatedUsername = getByLabelText('Bio');
+    const inputElement = updatedUsername as HTMLTextAreaElement;
+    // Assert
+    expect(inputElement.value).toBe('new bio');
+  });
+
+  test('change password tab contains 3 fields', async () => {
+    // Arrange
+    const { getByText, findAllByAltText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    // Act
+    const tab = getByText('Change Password');
+    fireEvent.click(tab);
+    const passwordFields = await waitFor(() =>
+      findAllByAltText('password-field'),
+    );
+    // Assert
+    expect(passwordFields.length).toBe(3);
+  });
+
+  test('change password form shows error if any or all fields left blank', () => {
+    // Arrange
+    const { getByText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    const tab = getByText('Change Password');
+    fireEvent.click(tab);
+
+    // Act
+    const saveButton = getByText('Save');
+    fireEvent.click(saveButton);
+    const message = getByText('Provide a value for all fields.');
+
+    // Assert
+    expect(message).toBeDefined();
+    expect(message).toBeVisible();
+  });
+
+  test("change password form shows error if new passwords don't match", () => {
+    // Arrange
+    const { getByText, getByLabelText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    const tab = getByText('Change Password');
+    fireEvent.click(tab);
+
+    const newPasswordInput = getByLabelText('New Password');
+    fireEvent.change(newPasswordInput, { target: { value: 'newPassword' } });
+
+    const confirmNewPasswordInput = getByLabelText('Confirm New Password');
+    fireEvent.change(confirmNewPasswordInput, {
+      target: { value: 'newPassword1' },
+    });
+
+    const oldPasswordInput = getByLabelText('Old Password');
+    fireEvent.change(oldPasswordInput, { target: { value: 'oldPassword' } });
+
+    // Act
+    const saveButton = getByText('Save');
+    fireEvent.click(saveButton);
+
+    const message = getByText("New passwords don't match.");
+    // Assert
+    expect(message).toBeDefined();
+    expect(message).toBeVisible();
+  });
+
+  test('change password form submits successfully with banner message', async () => {
+    // Arrange
+    const { getByText, getByLabelText } = render(
+      <MockThemeProvider>
+        <AccountSettings />
+      </MockThemeProvider>,
+    );
+    const tab = getByText('Change Password');
+    fireEvent.click(tab);
+
+    const newPasswordInput = getByLabelText('New Password');
+    fireEvent.change(newPasswordInput, { target: { value: 'newPassword' } });
+
+    const confirmNewPasswordInput = getByLabelText('Confirm New Password');
+    fireEvent.change(confirmNewPasswordInput, {
+      target: { value: 'newPassword' },
+    });
+
+    const oldPasswordInput = getByLabelText('Old Password');
+    fireEvent.change(oldPasswordInput, { target: { value: 'oldPassword' } });
+
+    // Act
+    const saveButton = getByText('Save');
+    fireEvent.click(saveButton);
+
+    const banner = await waitFor(() => getByText('Password updated.'));
+    // Assert
+    expect(banner).toBeDefined();
+    expect(banner).toBeVisible();
+  });
+});

--- a/src/components/account/account-settings.tsx
+++ b/src/components/account/account-settings.tsx
@@ -1,0 +1,53 @@
+import React, { FC, useState } from 'react';
+import { MainContent } from '@components/shared/containers/main-content';
+import { SettingsContainer } from '@components/shared/containers';
+import { ContainerSidePanel } from '@components/shared/side-panels';
+import { menuItems, getMenuItemContent } from './content/menu-items';
+import { MenuItem } from '@components/shared/side-panels/container-side-panel';
+
+export type StatusType = 'success' | 'error';
+
+export const AccountSettings: FC = () => {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>();
+  const [currentMenuItem, setCurrentMenuItem] = useState(menuItems[0].name);
+
+  const handleMenuItemClick = (name: string) => {
+    setCurrentMenuItem(name);
+  };
+
+  const handleStatusDisplay = (status: StatusType, message: string) => {
+    switch (status) {
+      case 'success':
+        setSuccess(message);
+        break;
+      case 'error':
+        setError(message);
+      default:
+        break;
+    }
+  };
+
+  return (
+    <SettingsContainer
+      error={error}
+      setError={setError}
+      success={success}
+      setSuccess={setSuccess}
+      isLoading={false}
+    >
+      <ContainerSidePanel>
+        {menuItems.map((m) => {
+          return (
+            <MenuItem onClick={() => handleMenuItemClick(m.name)} key={m.name}>
+              {m.name}
+            </MenuItem>
+          );
+        })}
+      </ContainerSidePanel>
+      <MainContent>
+        {getMenuItemContent(currentMenuItem, { handleStatusDisplay })}
+      </MainContent>
+    </SettingsContainer>
+  );
+};

--- a/src/components/account/account-settings.tsx
+++ b/src/components/account/account-settings.tsx
@@ -9,7 +9,7 @@ export type StatusType = 'success' | 'error';
 
 export const AccountSettings: FC = () => {
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>();
+  const [success, setSuccess] = useState<string | null>(null);
   const [currentMenuItem, setCurrentMenuItem] = useState(menuItems[0].name);
 
   const handleMenuItemClick = (name: string) => {

--- a/src/components/account/content/change-password-content.tsx
+++ b/src/components/account/content/change-password-content.tsx
@@ -85,9 +85,10 @@ export const ChangePasswordContent: FC<ContentProps> = (props) => {
         onChange={(e) => handleCurrentPasswordChange(e.target.value)}
         hasError={false}
         required={true}
+        alt="password-field"
       />
       <br />
-      <FormLabel htmlFor="new-password">New Passsword</FormLabel>
+      <FormLabel htmlFor="new-password">New Password</FormLabel>
       <FormInput
         type="password"
         name="new-password"
@@ -96,10 +97,11 @@ export const ChangePasswordContent: FC<ContentProps> = (props) => {
         onChange={(e) => handleNewPasswordChange(e.target.value)}
         hasError={false}
         required={true}
+        alt="password-field"
       />
       <br />
       <FormLabel htmlFor="confirmed-new-password">
-        Confirm New Passsword
+        Confirm New Password
       </FormLabel>
       <FormInput
         type="password"
@@ -109,6 +111,7 @@ export const ChangePasswordContent: FC<ContentProps> = (props) => {
         onChange={(e) => handleConfirmNewPasswordChange(e.target.value)}
         hasError={false}
         required={true}
+        alt="password-field"
       />
       <br />
       {formMessage != '' && (

--- a/src/components/account/content/change-password-content.tsx
+++ b/src/components/account/content/change-password-content.tsx
@@ -1,0 +1,124 @@
+import React, { FC, useState } from 'react';
+import {
+  Form,
+  FormLabel,
+  FormInput,
+  ButtonWrapper,
+} from '@components/shared/form';
+import { ApiButton } from '@components/shared/buttons';
+import { ServiceResolver, ChangePassword, ApiResponse } from '@api';
+import { ContentProps } from './menu-items';
+import styled from 'styled-components';
+
+const FormMessage = styled.small<{ isValid: boolean }>`
+  color: ${(props) => (props.isValid ? '' : 'red')};
+`;
+
+export const ChangePasswordContent: FC<ContentProps> = (props) => {
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmedNewPassword, setConfirmedNewPassword] = useState('');
+  const [formValid, setFormValid] = useState(true);
+  const [formMessage, setFormMessage] = useState('');
+
+  const handleCurrentPasswordChange = (password: string) => {
+    setOldPassword(password);
+  };
+
+  const handleNewPasswordChange = (password: string) => {
+    setNewPassword(password);
+  };
+
+  const handleConfirmNewPasswordChange = (password: string) => {
+    setConfirmedNewPassword(password);
+  };
+
+  const handleClick = async () => {
+    if (
+      oldPassword === '' ||
+      newPassword === '' ||
+      confirmedNewPassword === ''
+    ) {
+      setFormMessage('Provide a value for all fields.');
+      setFormValid(false);
+      return;
+    }
+
+    if (newPassword !== confirmedNewPassword) {
+      setFormMessage("New passwords don't match.");
+      setFormValid(false);
+      return;
+    }
+
+    const api = ServiceResolver.apiResolver();
+
+    try {
+      const changePassword: ChangePassword = {
+        oldPassword,
+        newPassword,
+        confirmedNewPassword,
+      };
+
+      (await api.changePassword(changePassword)) as ApiResponse<ChangePassword>;
+
+      setOldPassword('');
+      setNewPassword('');
+      setConfirmedNewPassword('');
+      if (props.handleStatusDisplay) {
+        props.handleStatusDisplay('success', 'Password updated.');
+      }
+    } catch (err) {
+      if (props.handleStatusDisplay) {
+        props.handleStatusDisplay('error', err.message);
+      }
+    }
+  };
+
+  return (
+    <Form>
+      <FormLabel htmlFor="old-password">Old Password</FormLabel>
+      <FormInput
+        type="password"
+        name="old-password"
+        id="old-password"
+        value={oldPassword}
+        onChange={(e) => handleCurrentPasswordChange(e.target.value)}
+        hasError={false}
+        required={true}
+      />
+      <br />
+      <FormLabel htmlFor="new-password">New Passsword</FormLabel>
+      <FormInput
+        type="password"
+        name="new-password"
+        id="new-password"
+        value={newPassword}
+        onChange={(e) => handleNewPasswordChange(e.target.value)}
+        hasError={false}
+        required={true}
+      />
+      <br />
+      <FormLabel htmlFor="confirmed-new-password">
+        Confirm New Passsword
+      </FormLabel>
+      <FormInput
+        type="password"
+        name="confirmed-new-password"
+        id="confirmed-new-password"
+        value={confirmedNewPassword}
+        onChange={(e) => handleConfirmNewPasswordChange(e.target.value)}
+        hasError={false}
+        required={true}
+      />
+      <br />
+      {formMessage != '' && (
+        <FormMessage isValid={formValid}>{formMessage}</FormMessage>
+      )}
+      <ButtonWrapper>
+        <ApiButton handleClick={handleClick} statusText="Saving">
+          Save
+        </ApiButton>
+      </ButtonWrapper>
+    </Form>
+  );
+};

--- a/src/components/account/content/menu-items.tsx
+++ b/src/components/account/content/menu-items.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement } from 'react';
+import { ProfileContent } from './profile-content';
+import { ChangePasswordContent } from './change-password-content';
+import { StatusType } from '../account-settings';
+
+export interface ContentProps {
+  handleStatusDisplay?: (status: StatusType, message: string) => void;
+}
+
+interface MenuItem {
+  name: string;
+  content: ReactElement;
+}
+
+export const menuItems: MenuItem[] = [
+  {
+    name: 'Change Password',
+    content: <ChangePasswordContent />,
+  },
+  {
+    name: 'Edit Profile',
+    content: <ProfileContent />,
+  },
+];
+
+export const getMenuItemContent = (name: string, props: ContentProps) => {
+  switch (name) {
+    case 'Change Password':
+      return <ChangePasswordContent {...props} />;
+    case 'Edit Profile':
+      return <ProfileContent {...props} />;
+  }
+};

--- a/src/components/account/content/profile-content.tsx
+++ b/src/components/account/content/profile-content.tsx
@@ -1,0 +1,203 @@
+import { debounce } from 'lodash';
+import React, {
+  FC,
+  ChangeEvent,
+  useState,
+  useCallback,
+  useContext,
+  useEffect,
+} from 'react';
+import styled from 'styled-components';
+import { ValueType } from 'react-select/src/types';
+
+import {
+  ServiceResolver,
+  User,
+  UserTechnology,
+  UserValidation,
+  ApiResponse,
+  Username,
+} from '@api';
+import { ContentProps } from './menu-items';
+import {
+  Form,
+  FormLabel,
+  FormInput,
+  FormTextArea,
+  ButtonWrapper,
+  TechnologiesSelect,
+} from '@components/shared/form';
+import { ApiButton } from '@components/shared/buttons';
+import { Image } from '@components/shared/side-panels';
+import { defaultProfileImage } from '@images';
+import { AuthContext } from '@contexts';
+
+interface OptionType {
+  label: string;
+  value: string;
+}
+
+const UsernameCheck = styled.small<{ isValid: boolean }>`
+  color: ${(props) => (props.isValid ? '' : 'red')};
+`;
+
+export const ProfileContent: FC<ContentProps> = (props) => {
+  const authContext = useContext(AuthContext);
+
+  const [user, setUser] = useState(authContext.member);
+  const [username, setUsername] = useState(authContext.member.username);
+  const [usernameAvailablity, setUsernameAvailability] = useState<
+    UserValidation
+  >({ valid: true, reason: '' });
+  const [bio, setBio] = useState(authContext.member.bio);
+  const [technologies, setTechnologies] = useState(
+    authContext.member.technologies,
+  );
+
+  useEffect(() => {
+    setUser(authContext.member);
+    setUsername(authContext.member.username);
+    setBio(authContext.member.bio);
+    setTechnologies(authContext.member.technologies);
+  }, [authContext.member]);
+
+  const handleClick = async () => {
+    const api = ServiceResolver.apiResolver();
+
+    try {
+      const updatedUser: User = {
+        ...user,
+        username,
+        bio,
+        technologies,
+      };
+      const response = (await api.editUser(updatedUser)) as ApiResponse<User>;
+      if (props.handleStatusDisplay) {
+        props.handleStatusDisplay('success', 'Settings saved');
+      }
+      setUser(response.data as User);
+      if (authContext.setMember) {
+        authContext.setMember(updatedUser);
+      }
+    } catch (err) {
+      if (props.handleStatusDisplay) {
+        props.handleStatusDisplay('error', err.message);
+      }
+    }
+  };
+
+  const handleTechnologiesError = (message: string) => {
+    if (props.handleStatusDisplay) {
+      props.handleStatusDisplay('error', message);
+    }
+  };
+
+  const handleUsernamValidation = async (
+    username: string,
+    currentUser: User | undefined,
+  ) => {
+    const api = ServiceResolver.apiResolver();
+    const u: Username = {
+      username,
+    };
+
+    if (username == currentUser?.username) {
+      setUsernameAvailability({ valid: true, reason: '' });
+      return;
+    }
+
+    try {
+      const response = (await api.validateUsername(u)) as ApiResponse<
+        UserValidation
+      >;
+      setUsernameAvailability(response.data as UserValidation);
+    } catch {
+      setUsernameAvailability({
+        valid: false,
+        reason: 'Failed to validate username',
+      });
+    }
+  };
+
+  const debouncedUsernameValidation = useCallback(
+    debounce(handleUsernamValidation, 450),
+    [],
+  );
+
+  const handleUsernameChange = (username: string) => {
+    setUsername(username);
+    setUsernameAvailability({ valid: true, reason: 'checking...' });
+    debouncedUsernameValidation(username, user);
+  };
+
+  const handleSelectChange = (e: ValueType<OptionType>) => {
+    const userId = user?.id === undefined ? '' : user.id;
+    const updatedTechnologies: UserTechnology[] = Array.isArray(e)
+      ? e.map((v) => {
+          const userTech = technologies.find((t) => t.name == v);
+          if (userTech == undefined) {
+            return { name: v, userId };
+          } else {
+            return { name: v, userId, id: userTech.id };
+          }
+        })
+      : [];
+
+    setTechnologies(updatedTechnologies);
+  };
+
+  return (
+    <Form>
+      <Image
+        src={(user && user.profilePictureUrl) || defaultProfileImage}
+        width="64"
+        height="64"
+      />
+      <FormLabel htmlFor="username">Username</FormLabel>
+      <FormInput
+        type="text"
+        name="username"
+        id="username"
+        value={username}
+        onChange={(e) => handleUsernameChange(e.target.value)}
+        hasError={!usernameAvailablity.valid}
+      />
+      {usernameAvailablity.reason != '' && username != user?.username && (
+        <UsernameCheck isValid={usernameAvailablity.valid}>
+          {usernameAvailablity.reason}
+        </UsernameCheck>
+      )}
+      <br />
+      <br />
+
+      <FormLabel htmlFor="bio">Bio</FormLabel>
+
+      <FormTextArea
+        name="bio"
+        id="bio"
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setBio(e.target.value)}
+        value={bio}
+        rows={5}
+      >
+        {bio}
+      </FormTextArea>
+      <br />
+
+      <FormLabel htmlFor="technologies">Technologies</FormLabel>
+      {/* TODO technologies are not being rendered on refresh */}
+      <TechnologiesSelect
+        name="technologies"
+        id="technologies"
+        setError={handleTechnologiesError}
+        initialValues={technologies}
+        setTechnologies={handleSelectChange}
+      />
+
+      <ButtonWrapper>
+        <ApiButton handleClick={handleClick} statusText="Saving">
+          Save
+        </ApiButton>
+      </ButtonWrapper>
+    </Form>
+  );
+};

--- a/src/components/shared/__tests__/account-settings.spec.tsx
+++ b/src/components/shared/__tests__/account-settings.spec.tsx
@@ -6,7 +6,7 @@ import { MockAuthService } from '@mocks';
 import { SignIn, JwtToken } from '@api';
 import { SessionStorageHelper } from '@helpers';
 
-describe('test account settings component', () => {
+describe.skip('test account settings component', () => {
   // Test suite setup
   beforeEach(() => {
     // emulate existing user login

--- a/src/components/shared/form/controls/technologies-select.tsx
+++ b/src/components/shared/form/controls/technologies-select.tsx
@@ -131,7 +131,7 @@ export const TechnologiesSelect: FC<TechnologiesSelectProps> = ({
 
       return options;
     } catch (error) {
-      setError('Failed to get tags');
+      setError('Failed to populate technologies');
     }
   };
 

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -13,17 +13,24 @@ import { SessionStorageHelper, UserAuthHelper } from '@helpers';
 interface AuthContextState {
   authenticated: boolean;
   avatar: string;
-  member?: User;
+  member: User;
   signIn?: (
     credentials: SignIn,
   ) => Promise<ApiResponse<JwtToken | ErrorResponse>>;
   signOut?: () => void;
+  setMember?: (user: User) => void;
 }
+
+const defaultMember: User = {
+  username: '',
+  bio: '',
+  technologies: [],
+};
 
 const defaultAuthContextState: AuthContextState = {
   authenticated: false,
   avatar: defaultProfileImage,
-  member: undefined,
+  member: defaultMember,
 };
 
 export const AuthContext = React.createContext(defaultAuthContextState);
@@ -77,13 +84,23 @@ export const AuthProvider: FC = (props) => {
     SessionStorageHelper.deleteJwt();
   };
 
+  const setMember = (user: User) => {
+    const authContext = {
+      ...authContextState,
+      member: user,
+      avatar: user.profilePictureUrl || defaultProfileImage,
+    };
+
+    setAuthContextState(authContext);
+  };
+
   useEffect(() => {
     const initializeAuthContext = async () => {
       const isUserAuthenticated = UserAuthHelper.isUserAuthenticated();
       const defaultAuthContextState: AuthContextState = {
         authenticated: isUserAuthenticated,
         avatar: defaultProfileImage,
-        member: undefined,
+        member: defaultMember,
       };
 
       if (isUserAuthenticated) {
@@ -100,7 +117,9 @@ export const AuthProvider: FC = (props) => {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ ...authContextState, signIn, signOut }}>
+    <AuthContext.Provider
+      value={{ ...authContextState, signIn, signOut, setMember }}
+    >
       {props.children}
     </AuthContext.Provider>
   );

--- a/src/mocks/mock-api-service.ts
+++ b/src/mocks/mock-api-service.ts
@@ -9,7 +9,7 @@ import {
   createProject,
   user,
 } from './responses';
-import { Project, User } from '@api';
+import { Project, User, ChangePassword } from '@api';
 
 export class MockApiService {
   public async createProject(project: Project) {
@@ -46,5 +46,9 @@ export class MockApiService {
 
   public async editUser(_user: User) {
     return user;
+  }
+
+  public async changePassword(changePassword: ChangePassword) {
+    return changePassword;
   }
 }

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -2,7 +2,7 @@ import { navigate } from 'gatsby';
 import React, { FC, useEffect } from 'react';
 
 import { Layout, Seo } from '@components/shared';
-import { AccountSettings } from '@components/shared/containers';
+import { AccountSettings } from '@components/account/account-settings';
 import { UserAuthHelper } from '@helpers';
 import { useSiteMetadata } from '@hooks';
 


### PR DESCRIPTION
- move account settings logic to new directory src > components > account
- break up account-settings.tsx into their own logical parts that we can extend when we add new tabs/content
- Add menu-items.tsx with helper method - iterated by account-settings.tsx to render menu items and their content
- Add `x-content.tsx` files that each correspond to a single menu item. 
- Rely on auth context to read any user state as needed for `profile-content.tsx`.
- Add client side validation and display banners on successful save or error

<img width="851" alt="Screen Shot 2020-05-20 at 5 14 50 PM" src="https://user-images.githubusercontent.com/4195689/82526765-624df880-9afa-11ea-94f8-59c11c18d16a.png">
