### PR TITLE
add forgot password form, add form tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.9",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/src/api/auth-service.ts
+++ b/src/api/auth-service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from './http-client';
-import { SignIn, SignUp, PasswordReset } from './types';
+import { SignIn, SignUp, ResetPasswordRequest, ResetPassword } from './types';
 
 export class AuthService {
   private headers = {
@@ -28,11 +28,21 @@ export class AuthService {
     );
   }
 
-  public async resetPassword(passwordReset: PasswordReset) {
+  public async resetPasswordRequest(
+    resetPasswordRequest: ResetPasswordRequest,
+  ) {
+    return await HttpClient.post(
+      `${this.apiEndpoint}/auth/reset-passsword-request`,
+      this.headers,
+      resetPasswordRequest,
+    );
+  }
+
+  public async resetPassword(resetPassword: ResetPassword) {
     return await HttpClient.post(
       `${this.apiEndpoint}/auth/reset-passsword`,
       this.headers,
-      passwordReset,
+      resetPassword,
     );
   }
 }

--- a/src/api/auth-service.ts
+++ b/src/api/auth-service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from './http-client';
-import { SignIn, SignUp } from './types';
+import { SignIn, SignUp, PasswordReset } from './types';
 
 export class AuthService {
   private headers = {
@@ -25,6 +25,14 @@ export class AuthService {
       `${this.apiEndpoint}/auth/register`,
       this.headers,
       signUp,
+    );
+  }
+
+  public async resetPassword(passwordReset: PasswordReset) {
+    return await HttpClient.post(
+      `${this.apiEndpoint}/auth/reset-passsword`,
+      this.headers,
+      passwordReset,
     );
   }
 }

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -14,3 +14,4 @@ export * from './user';
 export * from './user-technology';
 export * from './username';
 export * from './change-password';
+export * from './password-reset';

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -14,4 +14,5 @@ export * from './user';
 export * from './user-technology';
 export * from './username';
 export * from './change-password';
-export * from './password-reset';
+export * from './reset-password-request';
+export * from './reset-password';

--- a/src/api/types/password-reset.ts
+++ b/src/api/types/password-reset.ts
@@ -1,0 +1,3 @@
+export interface PasswordReset {
+  email: string;
+}

--- a/src/api/types/password-reset.ts
+++ b/src/api/types/password-reset.ts
@@ -1,3 +1,0 @@
-export interface PasswordReset {
-  email: string;
-}

--- a/src/api/types/reset-password-request.ts
+++ b/src/api/types/reset-password-request.ts
@@ -1,0 +1,3 @@
+export interface ResetPasswordRequest {
+  email: string;
+}

--- a/src/api/types/reset-password.ts
+++ b/src/api/types/reset-password.ts
@@ -1,0 +1,5 @@
+export interface ResetPassword {
+  newPassword: string;
+  confirmNewPassword: string;
+  validationToken: string;
+}

--- a/src/components/account/__tests__/account-settings.spec.tsx
+++ b/src/components/account/__tests__/account-settings.spec.tsx
@@ -168,9 +168,7 @@ describe('test account settings component', () => {
     // Act
     const tab = getByText('Change Password');
     fireEvent.click(tab);
-    const passwordFields = await waitFor(() =>
-      findAllByAltText('password-field'),
-    );
+    const passwordFields = await findAllByAltText('password-field');
     // Assert
     expect(passwordFields.length).toBe(3);
   });

--- a/src/components/shared/form/__tests__/forgot-password.spec.tsx
+++ b/src/components/shared/form/__tests__/forgot-password.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import { MockThemeProvider } from '@mocks';
@@ -66,8 +66,8 @@ describe('Forgot password form tests', () => {
     const emailInput = getByLabelText('Email');
     fireEvent.change(emailInput, { target: { value: 'pub@email.com' } });
     fireEvent.click(submit);
-    const message = await waitFor(() =>
-      findByText('Check your email for the password reset link.'),
+    const message = await findByText(
+      'Check your email for the password reset link.',
     );
 
     // Assert

--- a/src/components/shared/form/__tests__/forgot-password.spec.tsx
+++ b/src/components/shared/form/__tests__/forgot-password.spec.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { MockThemeProvider } from '@mocks';
+import { ForgotPasswordForm } from '../forgot-password';
+
+describe('Forgot password form tests', () => {
+  test('show email input', () => {
+    const { getByLabelText } = render(
+      <MockThemeProvider>
+        <ForgotPasswordForm />
+      </MockThemeProvider>,
+    );
+
+    const email = getByLabelText(/email/i, { selector: 'input' });
+
+    expect(email).toBeInTheDocument();
+    expect(email).toHaveAttribute('type', 'email');
+  });
+
+  test('show message when email field left empty', () => {
+    // Arrange
+    const { getByText } = render(
+      <MockThemeProvider>
+        <ForgotPasswordForm />
+      </MockThemeProvider>,
+    );
+
+    // Act
+    const submit = getByText('Submit');
+    fireEvent.click(submit);
+    const message = getByText('Email is required.');
+    // Assert
+    expect(message).toBeInTheDocument();
+  });
+
+  test('shows message when email is invalid', () => {
+    // Arrange
+    const { getByText, getByLabelText } = render(
+      <MockThemeProvider>
+        <ForgotPasswordForm />
+      </MockThemeProvider>,
+    );
+
+    // Act
+    const submit = getByText('Submit');
+    const emailInput = getByLabelText('Email');
+    fireEvent.change(emailInput, { target: { value: 'invalid_email' } });
+    fireEvent.click(submit);
+    const message = getByText('Enter valid email.');
+
+    // Assert
+    expect(message).toBeInTheDocument();
+  });
+
+  test('shows message when email submitted successfully', async () => {
+    // Arrange
+    const { getByText, getByLabelText, findByText } = render(
+      <MockThemeProvider>
+        <ForgotPasswordForm />
+      </MockThemeProvider>,
+    );
+
+    // Act
+    const submit = getByText('Submit');
+    const emailInput = getByLabelText('Email');
+    fireEvent.change(emailInput, { target: { value: 'pub@email.com' } });
+    fireEvent.click(submit);
+    const message = await waitFor(() =>
+      findByText('Check your email for the password reset link.'),
+    );
+
+    // Assert
+    expect(message).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/form/__tests__/reset-password.spec.tsx
+++ b/src/components/shared/form/__tests__/reset-password.spec.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { MockThemeProvider } from '@mocks';
+import { ResetPasswordForm } from '../reset-password';
+
+describe('Reset password form tests', () => {
+  test('shows both password fields', () => {
+    const { getByLabelText } = render(
+      <MockThemeProvider>
+        <ResetPasswordForm token="test_token" />
+      </MockThemeProvider>,
+    );
+
+    const newPassword = getByLabelText('New Password', { selector: 'input' });
+    const confirmNewPassword = getByLabelText('Confirm New Password', {
+      selector: 'input',
+    });
+
+    expect(newPassword).toBeInTheDocument();
+    expect(newPassword).toBeInTheDocument();
+    expect(confirmNewPassword).toHaveAttribute('type', 'password');
+    expect(confirmNewPassword).toHaveAttribute('type', 'password');
+  });
+
+  test('show message when password field(s) left empty', () => {
+    // Arrange
+    const { getByText } = render(
+      <MockThemeProvider>
+        <ResetPasswordForm token="test_token" />
+      </MockThemeProvider>,
+    );
+
+    // Act
+    const reset = getByText('Reset');
+    fireEvent.click(reset);
+    const message = getByText('Both password fields required.');
+    // Assert
+    expect(message).toBeInTheDocument();
+  });
+
+  test('show message when password token param not provided', () => {
+    // Arrange
+    const { getByText } = render(
+      <MockThemeProvider>
+        <ResetPasswordForm token={null} />
+      </MockThemeProvider>,
+    );
+
+    // Act
+    const message = getByText("Missing required 'token' query parameter.");
+    // Assert
+    expect(message).toBeInTheDocument();
+  });
+
+  test('show message when password dont match', () => {
+    // Arrange
+    const { getByText, getByLabelText } = render(
+      <MockThemeProvider>
+        <ResetPasswordForm token="test_token" />
+      </MockThemeProvider>,
+    );
+
+    // Act
+    const newPassword = getByLabelText('New Password', { selector: 'input' });
+    const confirmNewPassword = getByLabelText('Confirm New Password', {
+      selector: 'input',
+    });
+    fireEvent.change(newPassword, { target: { value: 'non-matching' } });
+    fireEvent.change(confirmNewPassword, { target: { value: 'passwords' } });
+
+    const reset = getByText('Reset');
+    fireEvent.click(reset);
+    const message = getByText('Password fields must match.');
+    // Assert
+    expect(message).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/form/__tests__/reset-password.spec.tsx
+++ b/src/components/shared/form/__tests__/reset-password.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import { MockThemeProvider } from '@mocks';

--- a/src/components/shared/form/__tests__/technologies-select.spec.tsx
+++ b/src/components/shared/form/__tests__/technologies-select.spec.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { MockThemeProvider } from '@mocks';
@@ -22,7 +22,7 @@ test('render TechnologiesSelect select component', async () => {
   );
 
   // Act
-  const select = await waitFor(() => findByText('Select...'));
+  const select = await findByText('Select...');
 
   // Assert
   expect(select).toBeInTheDocument();

--- a/src/components/shared/form/forgot-password.tsx
+++ b/src/components/shared/form/forgot-password.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useState } from 'react';
 import styled from 'styled-components';
 
 import { ApiButton } from '../buttons/api-button';
-import { ServiceResolver, PasswordReset } from '@api';
+import { ServiceResolver, ResetPasswordRequest } from '@api';
 import {
   FormLabel,
   FormInput,
@@ -54,11 +54,11 @@ export const ForgotPasswordForm: FC = () => {
     }
 
     const auth = ServiceResolver.authResolver();
-    const passwordReset: PasswordReset = {
+    const passwordReset: ResetPasswordRequest = {
       email,
     };
     try {
-      await auth.resetPassword(passwordReset);
+      await auth.resetPasswordRequest(passwordReset);
       setFormMessage('Check your email for the password reset link.');
     } catch (err) {
       setFormValid(false);

--- a/src/components/shared/form/forgot-password.tsx
+++ b/src/components/shared/form/forgot-password.tsx
@@ -1,0 +1,100 @@
+import React, { FC, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import { ApiButton } from '../buttons/api-button';
+import { ServiceResolver, PasswordReset } from '@api';
+import {
+  FormLabel,
+  FormInput,
+  ButtonWrapper,
+} from '@components/shared/form/controls';
+import { Form } from '@components/shared/form';
+
+const Wrapper = styled.section`
+  background-color: ${({ theme }) => theme.colors.section};
+
+  padding: ${({ theme }) => theme.boxes.padding.section.smallTop};
+
+  @media screen and(max-width: ${({ theme }) => theme.sizes.width.medium}) {
+    flex-direction: column;
+  }
+
+  @media screen and(max-width: ${({ theme }) => theme.sizes.width.small}) {
+    padding: ${({ theme }) => theme.boxes.padding.section.small};
+  }
+`;
+
+// TODO: Consider pulling FormMessage into Form since reporting
+// a message to user is common accross all app forms.
+const FormMessage = styled.small<{ isValid: boolean }>`
+  color: ${(props) => (props.isValid ? '' : 'red')};
+`;
+
+export const ForgotPasswordForm: FC = () => {
+  const [email, setEmail] = useState<string>('');
+  const [formValid, setFormValid] = useState(true);
+  const [formMessage, setFormMessage] = useState('');
+
+  const validEmail = (email: string) => {
+    const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(String(email).toLowerCase());
+  };
+
+  const handleClick = async () => {
+    if (email === '') {
+      setFormValid(false);
+      setFormMessage('Email is required.');
+      return;
+    }
+
+    if (!validEmail(email)) {
+      setFormValid(false);
+      setFormMessage('Enter valid email.');
+      return;
+    }
+
+    const auth = ServiceResolver.authResolver();
+    const passwordReset: PasswordReset = {
+      email,
+    };
+    try {
+      await auth.resetPassword(passwordReset);
+      setFormMessage('Check your email for the password reset link.');
+    } catch (err) {
+      setFormValid(false);
+      setFormMessage(err.message);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Form
+        heading={`Forgot password, No Worries.`}
+        subheading={`Enter the email you registered with.`}
+      >
+        <FormLabel htmlFor="forgot-password-email">Email</FormLabel>
+        <FormInput
+          name="forgot-password-email"
+          id="forgot-password-email"
+          type="email"
+          placeholder="unicorn@projectunicorn.net"
+          onChange={(e) => {
+            setEmail(e.target.value);
+            setFormValid(true);
+            setFormMessage('');
+          }}
+        />
+
+        {formMessage !== '' && (
+          <FormMessage isValid={formValid}>{formMessage}</FormMessage>
+        )}
+
+        <ButtonWrapper>
+          <ApiButton handleClick={handleClick} statusText="Submitting...">
+            Submit
+          </ApiButton>
+        </ButtonWrapper>
+      </Form>
+    </Wrapper>
+  );
+};

--- a/src/components/shared/form/forgot-password.tsx
+++ b/src/components/shared/form/forgot-password.tsx
@@ -31,13 +31,13 @@ const FormMessage = styled.small<{ isValid: boolean }>`
 `;
 
 export const ForgotPasswordForm: FC = () => {
-  const [email, setEmail] = useState<string>('');
+  const [email, setEmail] = useState('');
   const [formValid, setFormValid] = useState(true);
   const [formMessage, setFormMessage] = useState('');
 
   const validEmail = (email: string) => {
     const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    return re.test(String(email).toLowerCase());
+    return re.test(email.toLowerCase());
   };
 
   const handleClick = async () => {

--- a/src/components/shared/form/form.tsx
+++ b/src/components/shared/form/form.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 const Heading = styled.h2``;
 
+const Subheading = styled.p``;
+
 const FormElement = styled.form`
   display: flex;
   flex-direction: column;
@@ -11,10 +13,16 @@ const FormElement = styled.form`
 
 type FormProps = {
   heading?: string;
+  subheading?: string;
   handleSubmit?: Function;
 };
 
-export const Form: FC<FormProps> = ({ handleSubmit, heading, children }) => {
+export const Form: FC<FormProps> = ({
+  handleSubmit,
+  heading,
+  children,
+  subheading,
+}) => {
   const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     handleSubmit && handleSubmit(e);
@@ -25,6 +33,7 @@ export const Form: FC<FormProps> = ({ handleSubmit, heading, children }) => {
       onSubmit={(e: FormEvent<HTMLFormElement>) => handleFormSubmit(e)}
     >
       {heading && <Heading>{heading}</Heading>}
+      {subheading && <Subheading>{subheading}</Subheading>}
       {children}
     </FormElement>
   );

--- a/src/components/shared/form/index.ts
+++ b/src/components/shared/form/index.ts
@@ -1,5 +1,6 @@
 export { CreateProjectForm } from './create-project';
 export { SignUpForm } from './sign-up';
+export { ForgotPasswordForm } from './forgot-password';
 export { SignInForm } from './sign-in';
 export { Form } from './form';
 export { FeedbackForm } from './feedback';

--- a/src/components/shared/form/reset-password.tsx
+++ b/src/components/shared/form/reset-password.tsx
@@ -1,0 +1,126 @@
+import React, { FC, useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import { ApiButton } from '../buttons/api-button';
+import { ServiceResolver, ResetPassword } from '@api';
+import {
+  FormLabel,
+  FormInput,
+  ButtonWrapper,
+} from '@components/shared/form/controls';
+import { Form } from '@components/shared/form';
+import { navigate } from 'gatsby';
+
+const Wrapper = styled.section`
+  background-color: ${({ theme }) => theme.colors.section};
+
+  padding: ${({ theme }) => theme.boxes.padding.section.smallTop};
+
+  @media screen and(max-width: ${({ theme }) => theme.sizes.width.medium}) {
+    flex-direction: column;
+  }
+
+  @media screen and(max-width: ${({ theme }) => theme.sizes.width.small}) {
+    padding: ${({ theme }) => theme.boxes.padding.section.small};
+  }
+`;
+
+// TODO: Consider pulling FormMessage into Form since reporting
+// a message to user is common accross all app forms.
+const FormMessage = styled.small<{ isValid: boolean }>`
+  color: ${(props) => (props.isValid ? '' : 'red')};
+`;
+
+interface ResetPasswordFormProps {
+  token: string | null;
+}
+
+export const ResetPasswordForm: FC<ResetPasswordFormProps> = (props) => {
+  const [newPassword, setNewPassword] = useState<string>('');
+  const [confirmNewPassword, setConfirmNewPassword] = useState<string>('');
+  const [formValid, setFormValid] = useState(true);
+  const [formMessage, setFormMessage] = useState('');
+
+  useEffect(() => {
+    if (props.token == null) {
+      setFormValid(false);
+      setFormMessage("Missing required 'token' query parameter.");
+    }
+  });
+
+  const handleClick = async () => {
+    if (props.token == null) {
+      return;
+    }
+
+    if (newPassword === '' || confirmNewPassword === '') {
+      setFormValid(false);
+      setFormMessage('Both password fields required.');
+      return;
+    }
+
+    if (newPassword !== confirmNewPassword) {
+      setFormValid(false);
+      setFormMessage('Password fields must match.');
+      return;
+    }
+
+    const auth = ServiceResolver.authResolver();
+    const passwordReset: ResetPassword = {
+      newPassword,
+      confirmNewPassword,
+      validationToken: props.token,
+    };
+
+    try {
+      await auth.resetPassword(passwordReset);
+      setFormMessage('Password reset. Redirecting to login.');
+      navigate('/signin');
+    } catch (err) {
+      setFormValid(false);
+      setFormMessage(err.message);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Form heading={`Reset Password`} subheading={`Enter your new password.`}>
+        <FormLabel htmlFor="new-password">New Password</FormLabel>
+        <FormInput
+          name="new-password"
+          id="new-password"
+          type="password"
+          onChange={(e) => {
+            setNewPassword(e.target.value);
+            setFormValid(true);
+            setFormMessage('');
+          }}
+        />
+
+        <FormLabel htmlFor="confirm-new-password">
+          Confirm New Password
+        </FormLabel>
+        <FormInput
+          name="confirm-new-password"
+          id="confirm-new-password"
+          type="password"
+          onChange={(e) => {
+            setConfirmNewPassword(e.target.value);
+            setFormValid(true);
+            setFormMessage('');
+          }}
+        />
+
+        {formMessage !== '' && (
+          <FormMessage isValid={formValid}>{formMessage}</FormMessage>
+        )}
+
+        <ButtonWrapper>
+          <ApiButton handleClick={handleClick} statusText="Resetting...">
+            Reset
+          </ApiButton>
+        </ButtonWrapper>
+      </Form>
+    </Wrapper>
+  );
+};

--- a/src/components/shared/form/reset-password.tsx
+++ b/src/components/shared/form/reset-password.tsx
@@ -42,14 +42,14 @@ export const ResetPasswordForm: FC<ResetPasswordFormProps> = (props) => {
   const [formMessage, setFormMessage] = useState('');
 
   useEffect(() => {
-    if (props.token == null) {
+    if (props.token === null || props.token === '') {
       setFormValid(false);
       setFormMessage("Missing required 'token' query parameter.");
     }
-  });
+  }, [props.token]);
 
   const handleClick = async () => {
-    if (props.token == null) {
+    if (props.token === null) {
       return;
     }
 
@@ -84,7 +84,7 @@ export const ResetPasswordForm: FC<ResetPasswordFormProps> = (props) => {
 
   return (
     <Wrapper>
-      <Form heading={`Reset Password`} subheading={`Enter your new password.`}>
+      <Form heading="Reset Password" subheading="Enter your new password.">
         <FormLabel htmlFor="new-password">New Password</FormLabel>
         <FormInput
           name="new-password"

--- a/src/components/shared/form/sign-in.tsx
+++ b/src/components/shared/form/sign-in.tsx
@@ -109,7 +109,9 @@ export const SignInForm: FC<SignInFormProps> = ({ location }) => {
         <LinkWrapper>
           <Link to="/signup/">New member? Sign Up!</Link>
         </LinkWrapper>
-
+        <LinkWrapper>
+          <Link to="/forgot-password/">Forgot Password? Reset it!</Link>
+        </LinkWrapper>
         <ButtonWrapper>
           <ApiButton handleClick={handleClick} statusText="Signing In...">
             Sign In

--- a/src/components/shared/form/sign-in.tsx
+++ b/src/components/shared/form/sign-in.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import { ApiButton } from '../buttons/api-button';
 import { ApiResponse, ErrorResponse, JwtToken } from '@api';
-import { useSiteMetadata } from '@hooks';
 import {
   FormLabel,
   FormInput,
@@ -42,7 +41,6 @@ interface SignInFormProps {
 }
 
 export const SignInForm: FC<SignInFormProps> = ({ location }) => {
-  const siteMetadata = useSiteMetadata();
   const authContext = useContext(AuthContext);
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
@@ -80,7 +78,7 @@ export const SignInForm: FC<SignInFormProps> = ({ location }) => {
 
   return (
     <Wrapper>
-      <Form heading={`Sign In`}>
+      <Form heading="Sign In">
         {message && <Error>{message}</Error>}
         <FormLabel htmlFor="email-signin">Email</FormLabel>
         <FormInput

--- a/src/components/shared/form/sign-in.tsx
+++ b/src/components/shared/form/sign-in.tsx
@@ -80,7 +80,7 @@ export const SignInForm: FC<SignInFormProps> = ({ location }) => {
 
   return (
     <Wrapper>
-      <Form heading={`Sign In To ${siteMetadata.title}`}>
+      <Form heading={`Sign In`}>
         {message && <Error>{message}</Error>}
         <FormLabel htmlFor="email-signin">Email</FormLabel>
         <FormInput

--- a/src/mocks/mock-auth-service.ts
+++ b/src/mocks/mock-auth-service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { signUpResponse } from './responses/signup-response';
 import { signInResponse } from './responses/signin-response';
-import { SignUp, SignIn, PasswordReset } from '@api';
+import { SignUp, SignIn, ResetPasswordRequest, ResetPassword } from '@api';
 
 export class MockAuthService {
   public signIn(signIn: SignIn) {
@@ -12,7 +12,13 @@ export class MockAuthService {
     return signUpResponse;
   }
 
-  public async resetPassword(passwordReset: PasswordReset) {
-    return passwordReset;
+  public async resetPasswordRequest(
+    resetPasswordRequest: ResetPasswordRequest,
+  ) {
+    return resetPasswordRequest;
+  }
+
+  public async resetPassword(resetPassword: ResetPassword) {
+    return resetPassword;
   }
 }

--- a/src/mocks/mock-auth-service.ts
+++ b/src/mocks/mock-auth-service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { signUpResponse } from './responses/signup-response';
 import { signInResponse } from './responses/signin-response';
-import { SignUp, SignIn } from '@api';
+import { SignUp, SignIn, PasswordReset } from '@api';
 
 export class MockAuthService {
   public signIn(signIn: SignIn) {
@@ -10,5 +10,9 @@ export class MockAuthService {
 
   public async signUp(signUp: SignUp) {
     return signUpResponse;
+  }
+
+  public async resetPassword(passwordReset: PasswordReset) {
+    return passwordReset;
   }
 }

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -10,7 +10,7 @@ const ForgotPasswordPage: FC = () => {
   return (
     <Layout>
       <Seo
-        title={`Forgot Password`}
+        title="Forgot Password"
         description={`Forgot Password Page For ${siteMetadata.title}`}
         urlSlug="forgot-password/"
       />

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from 'react';
+
+import { Layout, Seo } from '@components/shared';
+import { ForgotPasswordForm } from '@components/shared/form';
+import { useSiteMetadata } from '@hooks';
+
+const ForgotPasswordPage: FC = () => {
+  const siteMetadata = useSiteMetadata();
+
+  return (
+    <Layout>
+      <Seo
+        title={`Forgot Password`}
+        description={`Forgot Password Page For ${siteMetadata.title}`}
+        urlSlug="forgot-password/"
+      />
+      <ForgotPasswordForm />
+    </Layout>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/src/pages/magic-login.tsx
+++ b/src/pages/magic-login.tsx
@@ -1,5 +1,5 @@
 import { Location } from '@reach/router';
-import React, { FC, Fragment, useState } from 'react';
+import React, { FC, Fragment, useState, useContext } from 'react';
 import { navigate } from 'gatsby';
 
 import { ApiResponse, ErrorResponse, JwtToken, ServiceResolver } from '@api';
@@ -12,9 +12,11 @@ import {
 } from '@components/shared';
 import { useSiteMetadata } from '@hooks';
 import { SessionStorageHelper } from '@helpers';
+import { AuthContext } from '@contexts';
 
 /** Page allows members to login via magic link method */
 const MagicLoginPage: FC = () => {
+  const authContext = useContext(AuthContext);
   const [message, setMessage] = useState<string>('Logging in...');
   const siteMetadata = useSiteMetadata();
 
@@ -25,24 +27,16 @@ const MagicLoginPage: FC = () => {
         setMessage('Login token missing.');
         return;
       }
-      const auth = ServiceResolver.authResolver();
 
       try {
-        const response = (await auth.signIn({
+        const response = (await authContext.signIn?.({
           email: 'token',
           password: token,
         })) as ApiResponse<JwtToken | ErrorResponse>;
 
-        // TODO: simplify, will always be true
-        if (response.ok) {
-          SessionStorageHelper.storeJwt(response.data as JwtToken);
-          navigate('/projects/');
-        } else {
-          // TODO: remove, will never be executed
-          setMessage((response.data as ErrorResponse).message);
-        }
+        SessionStorageHelper.storeJwt(response.data as JwtToken);
+        navigate('/projects/');
       } catch (err) {
-        // TODO: Log error
         setMessage(err.message);
       }
     }, 600);
@@ -60,9 +54,9 @@ const MagicLoginPage: FC = () => {
         }}
       </Location>
       <Seo
-        title={`${siteMetadata.title} - Contact Us`}
-        description={`Contact page for ${siteMetadata.title} website`}
-        urlSlug="contact/"
+        title={`${siteMetadata.title} - Magic Login`}
+        description={`Magic login page for ${siteMetadata.title} website`}
+        urlSlug="magin-login/"
       />
       <Container>
         <PageTitle>{message}</PageTitle>

--- a/src/pages/magic-login.tsx
+++ b/src/pages/magic-login.tsx
@@ -1,8 +1,8 @@
-import { Location } from '@reach/router';
-import React, { FC, Fragment, useState, useContext } from 'react';
+import { useLocation } from '@reach/router';
+import React, { FC, useState, useContext, useEffect } from 'react';
 import { navigate } from 'gatsby';
 
-import { ApiResponse, ErrorResponse, JwtToken, ServiceResolver } from '@api';
+import { ApiResponse, ErrorResponse, JwtToken } from '@api';
 import {
   Container,
   Layout,
@@ -16,6 +16,7 @@ import { AuthContext } from '@contexts';
 
 /** Page allows members to login via magic link method */
 const MagicLoginPage: FC = () => {
+  const location = useLocation();
   const authContext = useContext(AuthContext);
   const [message, setMessage] = useState<string>('Logging in...');
   const siteMetadata = useSiteMetadata();
@@ -42,17 +43,12 @@ const MagicLoginPage: FC = () => {
     }, 600);
   };
 
+  useEffect(() => {
+    handleLogin(new URLSearchParams(location.search).get('token'));
+  });
+
   return (
     <Layout>
-      {/* Using location to read token from URL Param
-          and log in member.
-      */}
-      <Location>
-        {({ location }) => {
-          handleLogin(new URLSearchParams(location.search).get('token'));
-          return <Fragment />;
-        }}
-      </Location>
       <Seo
         title={`${siteMetadata.title} - Magic Login`}
         description={`Magic login page for ${siteMetadata.title} website`}

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -1,11 +1,13 @@
-import { Location } from '@reach/router';
+import { useLocation } from '@reach/router';
 import React, { FC } from 'react';
+
 import { Layout, Seo } from '@components/shared';
 import { useSiteMetadata } from '@hooks';
 import { ResetPasswordForm } from '@components/shared/form/reset-password';
 
 const ResetPasswordPage: FC = () => {
   const siteMetadata = useSiteMetadata();
+  const location = useLocation();
   return (
     <Layout>
       <Seo
@@ -13,18 +15,9 @@ const ResetPasswordPage: FC = () => {
         description={`Reset Password page for ${siteMetadata.title} website`}
         urlSlug="reset-password/"
       />
-      {/* Using location to read token from URL Param
-          for validating password reset.
-      */}
-      <Location>
-        {({ location }) => {
-          return (
-            <ResetPasswordForm
-              token={new URLSearchParams(location.search).get('token')}
-            />
-          );
-        }}
-      </Location>
+      <ResetPasswordForm
+        token={new URLSearchParams(location.search).get('token')}
+      />
     </Layout>
   );
 };

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -1,0 +1,31 @@
+import { Location } from '@reach/router';
+import React, { FC } from 'react';
+import { Layout, Seo } from '@components/shared';
+import { useSiteMetadata } from '@hooks';
+import { ResetPasswordForm } from '@components/shared/form/reset-password';
+
+const ResetPasswordPage: FC = () => {
+  const siteMetadata = useSiteMetadata();
+  return (
+    <Layout>
+      <Seo
+        title={`${siteMetadata.title} - Reset Password`}
+        description={`Reset Password page for ${siteMetadata.title} website`}
+        urlSlug="reset-password/"
+      />
+      {/* Using location to read token from URL Param
+          for validating password reset.
+      */}
+      <Location>
+        {({ location }) => {
+          return (
+            <ResetPasswordForm
+              token={new URLSearchParams(location.search).get('token')}
+            />
+          );
+        }}
+      </Location>
+    </Layout>
+  );
+};
+export default ResetPasswordPage;


### PR DESCRIPTION
Summary - PR addresses password reset functionality. Includes 2 pages - forgot-password.tsx and reset-password.tsx. First page is used to submit email and trigger notification that generates a special url, Second page is used for user to reset their password using a token prop. The token is compared to a token stored on the server, PR also included api methods to support this functionality. 