### PR TITLE
Hide signup/signin pages from authenticated user, redirect to / if accessed

### DIFF
--- a/src/components/index-page/hero.tsx
+++ b/src/components/index-page/hero.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useSiteMetadata } from '@hooks';
 import { connectedWorld } from '@images';
 import ButtonTemplate from './button-template';
+import { UserAuthHelper } from '@helpers';
 
 const Wrapper = styled.header`
   align-items: center;
@@ -68,6 +69,7 @@ const Button = styled.button`
 /** Hero contains the web site's tag line and a call-to-action button. */
 const Hero: FC = () => {
   const siteMetadata = useSiteMetadata();
+  const isAuthenticated = UserAuthHelper.isUserAuthenticated();
 
   return (
     <Wrapper>
@@ -75,9 +77,15 @@ const Hero: FC = () => {
         <Heading>{siteMetadata.tag}</Heading>
         <SubHeading>{siteMetadata.description}</SubHeading>
 
-        <Link to="/signup">
-          <Button variant="default">Sign Up</Button>
-        </Link>
+        {(isAuthenticated && (
+          <Link to="/projects">
+            <Button variant="default">View Projects</Button>
+          </Link>
+        )) || (
+          <Link to="/signup">
+            <Button variant="default">Sign Up</Button>
+          </Link>
+        )}
       </Text>
 
       <ImageWrapper>

--- a/src/helpers/user-auth-helper.ts
+++ b/src/helpers/user-auth-helper.ts
@@ -10,6 +10,14 @@ export class UserAuthHelper {
     return !!jwt.token;
   }
 
+  public static redirectIfAuthenticated(redirectionUrl: string) {
+    if (this.isUserAuthenticated()) {
+      navigate(redirectionUrl, { replace: true });
+      return true;
+    }
+    return false;
+  }
+
   public static getMember() {
     const token = SessionStorageHelper.getJwt().token;
     if (!!token) {

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { SignInForm } from '@components/shared/form';
 import { Layout, Seo } from '@components/shared';
 import { useSiteMetadata } from '@hooks';
+import { UserAuthHelper } from '@helpers';
 
 interface SignInPageProps {
   location: {
@@ -14,6 +15,10 @@ interface SignInPageProps {
 
 const SignInPage: FC<SignInPageProps> = ({ location }) => {
   const siteMetadata = useSiteMetadata();
+  const redirected = UserAuthHelper.redirectIfAuthenticated('/');
+  if (redirected) {
+    return null;
+  }
 
   return (
     <Layout>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -3,10 +3,14 @@ import React, { FC } from 'react';
 import { Layout, Seo } from '@components/shared';
 import { SignUpForm } from '@components/shared/form';
 import { useSiteMetadata } from '@hooks';
+import { UserAuthHelper } from '@helpers';
 
 const SignUpPage: FC = () => {
   const siteMetadata = useSiteMetadata();
-
+  const redirected = UserAuthHelper.redirectIfAuthenticated('/');
+  if (redirected) {
+    return null;
+  }
   return (
     <Layout>
       <Seo


### PR DESCRIPTION
I didn't use `useEffect()` here since I didn't find a need to render the sign-in/sign-up page before the check. Returning `null` will not render anything.