### PR TITLE
Make nav items stateful

### DIFF
--- a/src/components/shared/__tests__/navigation.spec.tsx
+++ b/src/components/shared/__tests__/navigation.spec.tsx
@@ -22,6 +22,7 @@ describe('navigation', () => {
             isSidebarOpen={false}
             openSidebar={jest.fn()}
             navItems={defaultNavItems}
+            updateNavItems={jest.fn()}
           ></Navigation>
         </MockThemeProvider>
       </AuthProvider>,

--- a/src/components/shared/navigation/navigation.tsx
+++ b/src/components/shared/navigation/navigation.tsx
@@ -13,6 +13,7 @@ interface OwnProps {
   isSidebarOpen: boolean;
   navItems?: NavItem[];
   openSidebar: () => void;
+  updateNavItems: () => void;
 }
 
 type NavigationProps = OwnProps;
@@ -101,6 +102,7 @@ const Navigation: FC<NavigationProps> = ({
   isSidebarOpen,
   navItems = [],
   openSidebar,
+  updateNavItems,
 }) => {
   const authContext = useContext(AuthContext);
 
@@ -109,18 +111,15 @@ const Navigation: FC<NavigationProps> = ({
       return;
     }
     authContext.signOut();
+    updateNavItems();
     navigate('/');
   };
 
-  const setAvatar = (avatar: string) => {
-    navItems.map((navItem) => {
-      if (navItem.key == 'user-avatar-dropdown') {
-        navItem.item = <Profile content={avatar} signOut={signOut} />;
-      }
-    });
-  };
-
-  setAvatar(authContext.avatar);
+  navItems.map((navItem) => {
+    if (navItem.key == 'user-avatar-dropdown') {
+      navItem.item = <Profile content={authContext.avatar} signOut={signOut} />;
+    }
+  });
 
   return (
     <Wrapper isAtTop={isAtTop} isVisible={isAtTop || isVisible}>

--- a/src/components/shared/navigation/profile.tsx
+++ b/src/components/shared/navigation/profile.tsx
@@ -1,5 +1,5 @@
 import { navigate } from 'gatsby';
-import React, { FC, useState, useRef } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { UserAuthHelper } from '@helpers';
@@ -65,20 +65,21 @@ const DropdownItem = styled.div`
 
 const Profile: FC<ProfileProps> = ({ content, isOnline = false, signOut }) => {
   const [expanded, setExpanded] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
 
-  const close = () => {
+  const close = useCallback(() => {
     setExpanded(false);
-    document.removeEventListener('click', close);
-  };
-
-  const setRef = (ref: HTMLDivElement | null) => {
-    dropdownRef.current = ref;
-    document.addEventListener('click', close);
-  };
+  }, []);
 
   const toggle = () => setExpanded((expanded) => !expanded);
   const goToProfile = () => navigate(`/profile/${UserAuthHelper.getUserId()}`);
+
+  useEffect(() => {
+    if (expanded) {
+      document.addEventListener('click', close);
+      return;
+    }
+    document.removeEventListener('click', close);
+  }, [expanded]);
 
   return (
     <Wrapper onClick={toggle}>
@@ -86,9 +87,16 @@ const Profile: FC<ProfileProps> = ({ content, isOnline = false, signOut }) => {
       {isOnline && <Dot src={dotIcon} height={16} width={16} alt="blue dot" />}
 
       {expanded ? (
-        <Dropdown onBlur={close} ref={setRef}>
+        <Dropdown>
           <DropdownItem onClick={goToProfile}>Profile</DropdownItem>
-          <DropdownItem onClick={signOut}>Sign Out</DropdownItem>
+          <DropdownItem
+            onClick={() => {
+              document.removeEventListener('click', close);
+              signOut();
+            }}
+          >
+            Sign Out
+          </DropdownItem>
         </Dropdown>
       ) : null}
     </Wrapper>

--- a/src/mocks/responses/get-recent-devs.ts
+++ b/src/mocks/responses/get-recent-devs.ts
@@ -19,31 +19,31 @@ export const getRecentDevs: ApiResponse<RecentDev[]> = {
     {
       id: '08d6c5e7-6100-c770-61c3-834f6474a77b',
       bio:
-        'Hi. I’m Dan. I’ve been working as a programmer for ~15 years now. Python, ML, NLP, server-side...',
+        "Hi. I'm Dan. I've been working as a programmer for ~15 years now. Python, ML, NLP, server-side...",
       updatedAt: today,
     },
     {
       id: '08d6c5e7-6100-c770-61c3-834f6474a77c',
       bio:
-        'Hi. I’m Dan. I’ve been working as a programmer for ~15 years now. Python, ML, NLP, server-side...',
+        "Hi. I'm Dan. I've been working as a programmer for ~15 years now. Python, ML, NLP, server-side...",
       updatedAt: oneDayAgo,
     },
     {
-      id: '08d6c5e7-6100-c770-61c3-834f6474a77c',
+      id: '08d6c5e7-6100-c770-61c3-834f6474a77d',
       bio:
-        'Hi. I’m Dan. I’ve been working as a programmer for ~15 years now. Python, ML, NLP, server-side...',
+        "Hi. I'm Dan. I've been working as a programmer for ~15 years now. Python, ML, NLP, server-side...",
       updatedAt: twoDaysAgo,
     },
     {
-      id: '08d6c5e7-6100-c770-61c3-834f6474a77d',
+      id: '08d6c5e7-6100-c770-61c3-834f6474a77e',
       bio:
-        'Hi. I’m Dan. I’ve been working as a programmer for ~15 years now. Python, ML, NLP, server-side...',
+        "Hi. I'm Dan. I've been working as a programmer for ~15 years now. Python, ML, NLP, server-side...",
       updatedAt: oneMonthAgo,
     },
     {
-      id: '08d6c5e7-6100-c770-61c3-834f6474a77d',
+      id: '08d6c5e7-6100-c770-61c3-834f6474a77f',
       bio:
-        'Hi. I’m Dan. I’ve been working as a programmer for ~15 years now. Python, ML, NLP, server-side...',
+        "Hi. I'm Dan. I've been working as a programmer for ~15 years now. Python, ML, NLP, server-side...",
       updatedAt: twoMonthsAgo,
     },
   ],


### PR DESCRIPTION
Fixes a bug where the navbar won't re-render if the user signs out while they are on the homepage.

For `layout.tsx` component
- Gets rid of `AuthState` since it is not used in the React element.
- Adds a state for `nav items` and passes it to `navigation.tsx`.

For `profile.tsx` component
- Gets rid of `onBlur` in `DropDown` since it has no effect.
- Gets rid of `useRef` since it is not used.
- Removes the `click` event listener on the profile image on signing out to avoid changing the state of a removed component.
- Uses `useEffect()` to add and remove event listeners on opening and closing the dropdown

For `recent-devs` mock
- Makes the IDs of the recent devs unique to avoid giving errors in the console
- Uses UTF-8 characters

